### PR TITLE
Allow hash reference as arguments to coerce()

### DIFF
--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -279,12 +279,10 @@ sub coerce {
 
   return $self->{coerce} ||= {} unless @args;
 
-  @args = (booleans => 1, numbers => 1, strings => 1) if $args[0] eq '1';    # back compat
-  while (@args) {
-    my $k = shift @args;
-    $self->{coerce}{$k} = shift @args;
+  if( $args[0] eq '1'){   # back compat
+    @args = (booleans => 1, numbers => 1, strings => 1) ;
   }
-
+  $self->{coerce} = @args > 1 ? {@args} : {%{$args[0]}};
   return $self;
 }
 

--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -738,7 +738,7 @@ sub _validate_type_boolean {
   my ($self, $value, $path, $schema) = @_;
 
   if (defined $value) {
-    if (Scalar::Util::blessed($value) and ("$value" eq "1" or !$value)) {
+    if (Scalar::Util::blessed($value) and ("$value" =~ /^true|1$/ or !$value)) {
       return;
     }
     if ($self->{coerce}{booleans} and (B::svref_2object(\$value)->FLAGS & B::SVp_NOK or $value =~ /^(true|false)$/)) {

--- a/t/booleans.t
+++ b/t/booleans.t
@@ -24,6 +24,23 @@ for my $value ("true", "false") {
   ok !@errors, "boolean ($value). (@errors)";
 }
 
+SKIP:{
+  skip 'Mojo::JSON::MaybeXS is not installed'
+    unless eval {require Mojo::JSON::MaybeXS};
+  my $schema = {properties => {disabled => {type => "boolean"}}};
+  $validator = JSON::Validator->new->schema($schema);
+  $validator->coerce(booleans => 0);
+  my $objects = [{disabled => 1}, {disabled => 0}];
+  for my $o (@$objects){
+    $o->{disabled}
+      ? ($o->{disabled} = Mojo::JSON->true)
+      : ($o->{disabled} = Mojo::JSON->false);
+    @errors = $validator->validate($o);
+    ok !@errors, "boolean via Mojo::JSON::MaybeXS ($o->{disabled}). (@errors)";
+  }
+}
+
+
 SKIP: {
   skip 'YAML::XS is not installed', 1 unless eval 'require YAML::XS;1';
   $validator->coerce(booleans => 0);    # see that _load_schema_from_text() turns it back on

--- a/t/booleans.t
+++ b/t/booleans.t
@@ -25,8 +25,8 @@ for my $value ("true", "false") {
 }
 
 SKIP:{
-  skip 'Mojo::JSON::MaybeXS is not installed'
-    unless eval {require Mojo::JSON::MaybeXS};
+  skip 'One of Cpanel::JSON::XS or Mojo::JSON::MaybeXS is not installed.'
+    unless eval {require Cpanel::JSON::XS && require Mojo::JSON::MaybeXS};
   my $schema = {properties => {disabled => {type => "boolean"}}};
   $validator = JSON::Validator->new->schema($schema);
   $validator->coerce(booleans => 0);

--- a/t/coerce-args.t
+++ b/t/coerce-args.t
@@ -1,0 +1,11 @@
+use Mojo::Base -strict;
+use Test::More;
+use JSON::Validator;
+
+my $validator = JSON::Validator->new;
+my %coerce = (booleans => 1);
+is_deeply($validator->coerce(%coerce)->coerce,  {booleans => 1}, 'hash is accepted');
+is_deeply($validator->coerce(\%coerce)->coerce, {booleans => 1}, 'hash reference is accepted');
+is_deeply($validator->coerce(1)->coerce, {%coerce, numbers => 1, strings => 1}, '1 is accepted');
+
+done_testing;


### PR DESCRIPTION
as this is the only way to ask for only one type of coercion from
a mojo configuration file.
Keep backward compatibility.