### PR TITLE
_merge_errors syntax fix

### DIFF
--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -703,7 +703,7 @@ sub _load_yaml {
 sub _merge_errors {
   join ' ', map {
     my $e = $_;
-    @$e ? $e->[0]{message} : sprintf '(%s)', join '. ', map { $_->{message} } @$e;
+    (@$e == 1) ? $e->[0]{message} : sprintf '(%s)', join '. ', map { $_->{message} } @$e;
   } @_;
 }
 


### PR DESCRIPTION
The sprintf would never get called with a non-empty arrayref before this
fix