### PR TITLE
Prettier allOf, anyOf and oneOf error messages

### DIFF
--- a/lib/JSON/Validator/Error.pm
+++ b/lib/JSON/Validator/Error.pm
@@ -9,6 +9,7 @@ use overload
 sub new {
   my $self = bless {}, shift;
   @$self{qw(path message)} = ($_[0] || '/', $_[1] || '');
+  $self->{$_} = $_[2]->{$_} for keys %{$_[2] || {}};
   $self;
 }
 

--- a/t/Helper.pm
+++ b/t/Helper.pm
@@ -1,0 +1,30 @@
+package t::Helper;
+use Mojo::Base -strict;
+use Mojo::JSON 'encode_json';
+use Mojo::Util 'monkey_patch';
+use JSON::Validator;
+
+my $validator = JSON::Validator->new;
+
+sub validate_ok {
+  my ($schema, $data, $expected) = @_;
+  my $description ||= @$expected ? "errors: @$expected" : "valid: " . encode_json($data);
+  my @errors = $validator->validate($data, $schema);
+  Test::More::is_deeply([map { $_->TO_JSON } sort { $a->path cmp $b->path } @errors],
+    [map { $_->TO_JSON } sort { $a->path cmp $b->path } @$expected], $description)
+    or Test::More::diag(Data::Dumper::Dumper(\@errors));
+}
+
+sub import {
+  my $class  = shift;
+  my $caller = caller;
+
+  strict->import;
+  warnings->import;
+  monkey_patch $caller => E           => \&JSON::Validator::E;
+  monkey_patch $caller => false       => \&Mojo::JSON::false;
+  monkey_patch $caller => true        => \&Mojo::JSON::true;
+  monkey_patch $caller => validate_ok => \&validate_ok;
+}
+
+1;

--- a/t/jv-anyof.t
+++ b/t/jv-anyof.t
@@ -1,54 +1,90 @@
-use Mojo::Base -strict;
+use t::Helper;
 use Test::More;
-use JSON::Validator;
 
-my $validator = JSON::Validator->new;
 my $schema = {anyOf => [{type => "string", maxLength => 5}, {type => "number", minimum => 0}]};
-my @errors;
-
-@errors = $validator->validate("short", $schema);
-is "@errors", "", "short";
-
-@errors = $validator->validate("too long", $schema);
-is "@errors", "/: anyOf failed: String is too long: 8/5.", "too long";
-
-@errors = $validator->validate(12, $schema);
-is "@errors", "", "number";
-
-@errors = $validator->validate(-1, $schema);
-is "@errors", "/: anyOf failed: -1 < minimum(0)", "negative";
-
-@errors = $validator->validate({}, $schema);
-is "@errors", "/: anyOf failed: Expected string or number, got object.", "object";
-
-# anyOf with schema of the same 'type'
+validate_ok $schema, 'short',    [];
+validate_ok $schema, 'too long', [E('/', 'anyOf[0]: String is too long: 8/5.')];
+validate_ok $schema, 12,         [];
+validate_ok $schema, -1,         [E('/', 'anyOf[1]: -1 < minimum(0)')];
+validate_ok $schema, {}, [E('/', 'Expected string or number, got object.')];
 
 # anyOf with explicit integer (where _guess_data_type returns 'number')
-my $schemaB = {anyOf => [{type => "integer"}, {minimum => 2}]};
+validate_ok {anyOf => [{type => "integer"}, {minimum => 2}]}, 1, [];
 
-@errors = $validator->validate(1, $schemaB);
-is "@errors", "", "schema 1 pass, schema 2 fail";
-
-@errors = $validator->validate(
-  {type => 'string'},
+# anyOf test with schema from http://json-schema.org/draft-04/schema
+validate_ok(
   {
     properties => {
-      type => {
+      whatever => {
         anyOf => [
           {'$ref' => '#/definitions/simpleTypes'},
           {
             type        => 'array',
             items       => {'$ref' => '#/definitions/simpleTypes'},
             minItems    => 1,
-            uniqueItems => Mojo::JSON::true,
+            uniqueItems => true,
           }
         ]
       },
     },
     definitions => {simpleTypes => {enum => [qw(array boolean integer null number object string)]}}
-  }
+  },
+  {whatever => ''},
+  [],
 );
 
-is "@errors", "", "anyOf test with schema from http://json-schema.org/draft-04/schema";
+# anyOf with nested anyOf
+$schema = {
+  anyOf => [
+    {
+      anyOf => [
+        {
+          type                 => 'object',
+          additionalProperties => false,
+          required             => ['id'],
+          properties           => {id => {type => 'integer', minimum => 1}},
+        },
+        {
+          type                 => 'object',
+          additionalProperties => false,
+          required             => ['id', 'name', 'role'],
+          properties           => {
+            id   => {type => 'integer', minimum => 1},
+            name => {type => 'string'},
+            role => {anyOf => [{type => 'string'}, {type => 'array'}]},
+          },
+        }
+      ]
+    },
+    {type => 'integer', minimum => 1}
+  ]
+};
+validate_ok(
+  $schema,
+  {id => 1, name => '', role => 123},
+  [E('/role', 'anyOf[0.1]: Expected string or array, got number.')]
+);
+validate_ok($schema, 'string not integer', [E('/', 'Expected integer or object, got string.')]);
+validate_ok($schema, {id => 1, name => 'Bob'}, [E('/role', 'anyOf[0.1]: Missing property.')]);
+validate_ok($schema, {id => 1, name => 'Bob', role => 'admin'}, []);
+
+validate_ok(
+  $schema,
+  {foo => 1},
+  [
+    E('/', 'anyOf[0.0]: Properties not allowed: foo.'),
+    E('/', 'anyOf[0.1]: Properties not allowed: foo.')
+  ],
+);
+validate_ok(
+  $schema,
+  {},
+  [
+    E('/id',   'anyOf[0.0]: Missing property.'),
+    E('/id',   'anyOf[0.1]: Missing property.'),
+    E('/name', 'anyOf[0.1]: Missing property.'),
+    E('/role', 'anyOf[0.1]: Missing property.'),
+  ]
+);
 
 done_testing;

--- a/t/jv-oneof.t
+++ b/t/jv-oneof.t
@@ -34,7 +34,7 @@ is "@errors", "/: oneOf failed: Not multiple of 3.", "multipleOf";
 $schema
   = {type => 'object', properties => {x => {type => ['string', 'null'], format => 'date-time'}}};
 @errors = $validator->validate({x => 'foo'}, $schema);
-is "@errors", "/x: anyOf failed: Does not match date-time format.", "date-time";
+is "@errors", "/x: anyOf[0]: Does not match date-time format.", "date-time";
 @errors = $validator->validate({x => '2015-04-21T20:30:43.000Z'}, $schema);
 is "@errors", "", "YYYY-MM-DDThh:mm:ss.fffZ";
 @errors = $validator->validate({x => undef}, $schema);


### PR DESCRIPTION
See also #15 and #21 and https://github.com/jhthorsen/json-validator/commit/2148a9b53361c50f51ca83e47946e47094799fb2

It is very, very important to run all the swagger2 tests before releasing this change to CPAN. (2148a9b53361c50f51ca83e47946e47094799fb2 broke Swagger2, even if all the tests are ok)

Also, for now it only has prettier anyOf messages. (imo)
