### PR TITLE
OpenAPI $ref fails directly under /paths and /definitions

### DIFF
--- a/t/openapi-ref.t
+++ b/t/openapi-ref.t
@@ -4,13 +4,14 @@ use JSON::Validator::OpenAPI;
 use Test::More;
 
 my $jv = JSON::Validator::OpenAPI->new(resolver => sub { });
+my $jv_resolver = JSON::Validator::OpenAPI->new;
 my $api_spec = $jv->schema('data://main/swagger2/issues/89.json')->schema;
-my @errors = $jv->schema(JSON::Validator::OpenAPI::SPECIFICATION_URL())->validate($api_spec->data);
+my @errors = $jv_resolver->schema(JSON::Validator::OpenAPI::SPECIFICATION_URL())->validate($api_spec->data);
 
 local $TODO = 'https://github.com/jhthorsen/swagger2/issues/89';
 diag dumper($api_spec->data) if $ENV{JSON_VALIDATOR_DEBUG};
 diag dumper(\@errors) if $ENV{HARNESS_IS_VERBOSE};
-is @errors, 1, 'invalid spec';
+is @errors, 2, 'invalid spec';
 
 done_testing;
 


### PR DESCRIPTION
Currentyl openapi-ref.t is skipping references for not only our test spec, but also OpenAPI spec. We need to resolve $refs in OpenAPI spec in order to have correct rules, meanwhile not resolving $refs for our test spec.