### PR TITLE
Make JSON::Validator::OpenAPI framework-independent

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -14,7 +14,7 @@ WriteMakefile(
       repository => 'https://github.com/jhthorsen/json-validator.git',
     },
   },
-  BUILD_REQUIRES => {'Test::More'  => '0.88', 'Test::Warnings' => '0.016'},
-  PREREQ_PM      => {'Mojolicious' => '6.00'},
+  BUILD_REQUIRES => {'Test::More' => '0.88', 'Test::Warnings' => '0.016'},
+  PREREQ_PM      => {'Carp'       => 0,      'Mojolicious'    => '6.00'},
   test => {TESTS => (-e 'META.yml' ? 't/*.t' : 't/*.t xt/*.t')},
 );

--- a/lib/JSON/Validator/OpenAPI.pm
+++ b/lib/JSON/Validator/OpenAPI.pm
@@ -192,7 +192,7 @@ sub _validate_response_headers {
     }
     elsif ($input->{$name}) {
       push @errors, $self->validate($input->{$name}[0], $p);
-      $c->_set_response_data($c, 'header', $name => $input->{$name}[0] ? 'true' : 'false')
+      $self->_set_response_data($c, 'header', $name => $input->{$name}[0] ? 'true' : 'false')
         if $p->{type} eq 'boolean' and !@errors;
     }
   }

--- a/lib/JSON/Validator/OpenAPI.pm
+++ b/lib/JSON/Validator/OpenAPI.pm
@@ -10,6 +10,28 @@ my %COLLECTION_RE = (pipes => qr{\|}, csv => qr{,}, ssv => qr{\s}, tsv => qr{\t}
 
 has _json_validator => sub { state $v = JSON::Validator->new; };
 
+{    # proxy methods for compatibility
+  my @proxy_methods = qw<
+    _get_request_uploads
+    _get_request_data
+    _set_request_data
+    _get_response_data
+    _set_response_data
+  >;
+
+  for my $method (@proxy_methods) {
+    no strict 'refs';
+    *{__PACKAGE__ . "::$method"} = sub {
+      warn "Using JSON::Validator::OpenAPI directly is DEPRECATED."
+        . " For the Mojolicious-specific methods use JSON::Validator::OpenAPI::Mojolicious";
+
+      shift @_;
+      require JSON::Validator::OpenAPI::Mojolicious;
+      JSON::Validator::OpenAPI::Mojolicious->$method(@_);
+    };
+  }
+}
+
 sub validate_input {
   my $self = shift;
   local $self->{validate_input} = 1;

--- a/lib/JSON/Validator/OpenAPI.pm
+++ b/lib/JSON/Validator/OpenAPI.pm
@@ -30,7 +30,7 @@ sub validate_request {
       $exists = length $value if defined $value;
     }
     elsif ($in eq 'formData' and $type eq 'file') {
-      $value = $self->_get_request_uploads($c, $name);
+      ($value) = $self->_get_request_uploads($c, $name);
       $exists = $value ? 1 : 0;
     }
     else {

--- a/lib/JSON/Validator/OpenAPI.pm
+++ b/lib/JSON/Validator/OpenAPI.pm
@@ -1,5 +1,6 @@
 package JSON::Validator::OpenAPI;
 use Mojo::Base 'JSON::Validator';
+use Mojo::Util qw(deprecated);
 use Scalar::Util ();
 
 use constant DEBUG => $ENV{JSON_VALIDATOR_DEBUG} || 0;
@@ -22,7 +23,7 @@ has _json_validator => sub { state $v = JSON::Validator->new; };
   for my $method (@proxy_methods) {
     no strict 'refs';
     *{__PACKAGE__ . "::$method"} = sub {
-      warn "Using JSON::Validator::OpenAPI directly is DEPRECATED."
+      deprecated "Using JSON::Validator::OpenAPI directly is DEPRECATED."
         . " For the Mojolicious-specific methods use JSON::Validator::OpenAPI::Mojolicious";
 
       shift @_;

--- a/lib/JSON/Validator/OpenAPI.pm
+++ b/lib/JSON/Validator/OpenAPI.pm
@@ -1,4 +1,5 @@
 package JSON::Validator::OpenAPI;
+use Carp ();
 use Mojo::Base 'JSON::Validator';
 use Mojo::Util qw(deprecated);
 use Scalar::Util ();
@@ -250,6 +251,12 @@ sub _coerce_by_collection_format {
   }
 
   return $single ? $data->[0] : $data;
+}
+
+sub _invalid_in {
+  my ($self, $in) = @_;
+  Carp::confess(
+    "Unsupported \$in: $in. Please report at https://github.com/jhthorsen/json-validator");
 }
 
 sub _is_byte_string { $_[0] =~ /^[A-Za-z0-9\+\/\=]+$/ }

--- a/lib/JSON/Validator/OpenAPI/Dancer2.pm
+++ b/lib/JSON/Validator/OpenAPI/Dancer2.pm
@@ -32,7 +32,7 @@ sub _get_request_data {
 sub _get_request_uploads {
   my ($self, $dsl, $name) = @_;
 
-  return ($dsl->app->request->upload($name));    # context-aware
+  return ($dsl->app->request->upload($name));    # upload() is context-aware
 }
 
 sub _set_request_data {

--- a/lib/JSON/Validator/OpenAPI/Dancer2.pm
+++ b/lib/JSON/Validator/OpenAPI/Dancer2.pm
@@ -13,7 +13,7 @@ sub _get_request_data {
   return $app->dsl->body_parameters->as_hashref_mixed  if $in eq 'formData';
   return Hash::MultiValue->new($app->dsl->request->headers->flatten)->as_hashref_mixed
     if $in eq 'header';
-  return $app->dsl->request->body if $in eq 'body';
+  return $app->dsl->request->data if $in eq 'body';
   return {};    # TODO correct?
 }
 

--- a/lib/JSON/Validator/OpenAPI/Dancer2.pm
+++ b/lib/JSON/Validator/OpenAPI/Dancer2.pm
@@ -6,39 +6,39 @@ use Mojo::Base 'JSON::Validator::OpenAPI';
 ### request ###
 
 sub _get_request_data {
-  my ($self, $app, $in) = @_;
+  my ($self, $dsl, $in) = @_;
 
-  return $app->dsl->query_parameters->as_hashref_mixed if $in eq 'query';
-  return $app->dsl->route_parameters->as_hashref_mixed if $in eq 'path';
-  return $app->dsl->body_parameters->as_hashref_mixed  if $in eq 'formData';
-  return Hash::MultiValue->new($app->dsl->request->headers->flatten)->as_hashref_mixed
+  return $dsl->query_parameters->as_hashref_mixed if $in eq 'query';
+  return $dsl->route_parameters->as_hashref_mixed if $in eq 'path';
+  return $dsl->body_parameters->as_hashref_mixed  if $in eq 'formData';
+  return Hash::MultiValue->new($dsl->app->request->headers->flatten)->as_hashref_mixed
     if $in eq 'header';
-  return $app->dsl->request->data if $in eq 'body';
+  return $dsl->app->request->data if $in eq 'body';
   return {};    # TODO correct?
 }
 
 sub _get_request_uploads {
-  my ($self, $app, $name) = @_;
+  my ($self, $dsl, $name) = @_;
 
-  return ($app->request->upload($name));    # context-aware
+  return ($dsl->app->request->upload($name));    # context-aware
 }
 
 sub _set_request_data {
-  my ($self, $app, $in, $name => $value) = @_;
+  my ($self, $dsl, $in, $name => $value) = @_;
 
   if ($in eq 'query') {
-    $app->dsl->query_parameters->set($name => $value);
-    $app->dsl->request->params->{$name} = $value;
+    $dsl->query_parameters->set($name => $value);
+    $dsl->app->request->params->{$name} = $value;
   }
   elsif ($in eq 'path') {
-    $app->dsl->route_parameters->set($name => $value);
+    $dsl->route_parameters->set($name => $value);
   }
   elsif ($in eq 'formData') {
-    $app->dsl->request->body_parameters->set($name => $value);
-    $app->dsl->request->params->{$name} = $value;
+    $dsl->app->request->body_parameters->set($name => $value);
+    $dsl->app->request->params->{$name} = $value;
   }
   elsif ($in eq 'header') {
-    $app->dsl->request->headers->header($name => $value);
+    $dsl->app->request->headers->header($name => $value);
   }
   elsif ($in eq 'body') { }    # no need to write body back
   else {
@@ -50,10 +50,10 @@ sub _set_request_data {
 ### response
 
 sub _get_response_data {
-  my ($self, $app, $in) = @_;
+  my ($self, $dsl, $in) = @_;
 
   if ($in eq 'header') {
-    my @headers = $app->response->headers->flatten;
+    my @headers = $dsl->response->headers->flatten;
     return Hash::MultiValue->new(@headers)->as_hashref_mixed;
   }
 
@@ -61,9 +61,9 @@ sub _get_response_data {
 }
 
 sub _set_response_data {
-  my ($self, $app, $in, $name => $value) = @_;
+  my ($self, $dsl, $in, $name => $value) = @_;
 
-  $in eq 'header' and $app->response->headers->header($name => $value);
+  $in eq 'header' and $dsl->response->headers->header($name => $value);
 
   # TODO what else?
 }

--- a/lib/JSON/Validator/OpenAPI/Dancer2.pm
+++ b/lib/JSON/Validator/OpenAPI/Dancer2.pm
@@ -1,0 +1,71 @@
+package JSON::Validator::OpenAPI::Dancer2;
+
+use Hash::MultiValue;
+use Mojo::Base 'JSON::Validator::OpenAPI';
+
+### request ###
+
+sub _get_request_data {
+  my ($self, $app, $in) = @_;
+
+  return $app->dsl->query_parameters->as_hashref_mixed if $in eq 'query';
+  return $app->dsl->route_parameters->as_hashref_mixed if $in eq 'path';
+  return $app->dsl->body_parameters->as_hashref_mixed  if $in eq 'formData';
+  return Hash::MultiValue->new($app->dsl->request->headers->flatten)->as_hashref_mixed
+    if $in eq 'header';
+  return $app->dsl->request->body if $in eq 'body';
+  return {};    # TODO correct?
+}
+
+sub _get_request_uploads {
+  my ($self, $app, $name) = @_;
+
+  return ($app->request->upload($name));    # context-aware
+}
+
+sub _set_request_data {
+  my ($self, $app, $in, $name => $value) = @_;
+
+  if ($in eq 'query') {
+    $app->dsl->query_parameters->set($name => $value);
+    $app->dsl->request->params->{$name} = $value;
+  }
+  elsif ($in eq 'path') {
+    $app->dsl->route_parameters->set($name => $value);
+  }
+  elsif ($in eq 'formData') {
+    $app->dsl->request->body_parameters->set($name => $value);
+    $app->dsl->request->params->{$name} = $value;
+  }
+  elsif ($in eq 'header') {
+    $app->dsl->request->headers->header($name => $value);
+  }
+  elsif ($in eq 'body') { }    # no need to write body back
+  else {
+    die
+      "Cannot set default for $in => $name. Please submit a ticket here: https://github.com/jhthorsen/mojolicious-plugin-openapi";
+  }
+}
+
+### response
+
+sub _get_response_data {
+  my ($self, $app, $in) = @_;
+
+  if ($in eq 'header') {
+    my @headers = $app->response->headers->flatten;
+    return Hash::MultiValue->new(@headers)->as_hashref_mixed;
+  }
+
+  # TODO what else?
+}
+
+sub _set_response_data {
+  my ($self, $app, $in, $name => $value) = @_;
+
+  $in eq 'header' and $app->response->headers->header($name => $value);
+
+  # TODO what else?
+}
+
+1;

--- a/lib/JSON/Validator/OpenAPI/Dancer2.pm
+++ b/lib/JSON/Validator/OpenAPI/Dancer2.pm
@@ -1,5 +1,6 @@
 package JSON::Validator::OpenAPI::Dancer2;
 
+use Carp qw(confess);
 use Hash::MultiValue;
 use Mojo::Base 'JSON::Validator::OpenAPI';
 
@@ -14,7 +15,7 @@ sub _get_request_data {
   return Hash::MultiValue->new($dsl->app->request->headers->flatten)->as_hashref_mixed
     if $in eq 'header';
   return $dsl->app->request->data if $in eq 'body';
-  return {};    # TODO correct?
+  confess "Unsupported \$in: $in. Please report at https://github.com/jhthorsen/json-validator";
 }
 
 sub _get_request_uploads {

--- a/lib/JSON/Validator/OpenAPI/Mojolicious.pm
+++ b/lib/JSON/Validator/OpenAPI/Mojolicious.pm
@@ -1,5 +1,6 @@
 package JSON::Validator::OpenAPI::Mojolicious;
 
+use Carp qw(confess);
 use Mojo::Base 'JSON::Validator::OpenAPI';
 
 ### request ###
@@ -12,7 +13,7 @@ sub _get_request_data {
   return $c->req->body_params->to_hash(1) if $in eq 'formData';
   return $c->req->headers->to_hash(1)     if $in eq 'header';
   return $c->req->json                    if $in eq 'body';
-  return {};    # TODO correct?
+  confess "Unsupported \$in: $in. Please report at https://github.com/jhthorsen/json-validator";
 }
 
 sub _get_request_uploads {

--- a/lib/JSON/Validator/OpenAPI/Mojolicious.pm
+++ b/lib/JSON/Validator/OpenAPI/Mojolicious.pm
@@ -13,7 +13,7 @@ sub _get_request_data {
   return $c->req->body_params->to_hash(1) if $in eq 'formData';
   return $c->req->headers->to_hash(1)     if $in eq 'header';
   return $c->req->json                    if $in eq 'body';
-  confess "Unsupported \$in: $in. Please report at https://github.com/jhthorsen/json-validator";
+  $self->_invalid_in($in);
 }
 
 sub _get_request_uploads {
@@ -41,8 +41,7 @@ sub _set_request_data {
   }
   elsif ($in eq 'body') { }    # no need to write body back
   else {
-    die
-      "Cannot set default for $in => $name. Please submit a ticket here: https://github.com/jhthorsen/mojolicious-plugin-openapi";
+    $self->_invalid_in($in);
   }
 }
 
@@ -51,17 +50,23 @@ sub _set_request_data {
 sub _get_response_data {
   my ($self, $c, $in) = @_;
 
-  $in eq 'header' and return $c->res->headers->to_hash(1);
-
-  # TODO what else?
+  if ($in eq 'header') {
+    return $c->res->headers->to_hash(1);
+  }
+  else {
+    $self->_invalid_in($in);
+  }
 }
 
 sub _set_response_data {
   my ($self, $c, $in, $name => $value) = @_;
 
-  $in eq 'header' and $c->res->headers->header($name => ref $value ? @$value : $value);
-
-  # TODO what else?
+  if ($in eq 'header') {
+    $c->res->headers->header($name => ref $value ? @$value : $value);
+  }
+  else {
+    $self->_invalid_in($in);
+  }
 }
 
 1;

--- a/lib/JSON/Validator/OpenAPI/Mojolicious.pm
+++ b/lib/JSON/Validator/OpenAPI/Mojolicious.pm
@@ -11,14 +11,14 @@ sub _get_request_data {
   return $c->match->stack->[-1]           if $in eq 'path';
   return $c->req->body_params->to_hash(1) if $in eq 'formData';
   return $c->req->headers->to_hash(1)     if $in eq 'header';
-  return $c->req->body                    if $in eq 'body';
+  return $c->req->json                    if $in eq 'body';
   return {};    # TODO correct?
 }
 
 sub _get_request_uploads {
   my ($self, $c, $name) = @_;
 
-  return $c->req->every_upload($name);
+  return @{$c->req->every_upload($name)};
 }
 
 sub _set_request_data {

--- a/lib/JSON/Validator/OpenAPI/Mojolicious.pm
+++ b/lib/JSON/Validator/OpenAPI/Mojolicious.pm
@@ -1,0 +1,56 @@
+package JSON::Validator::OpenAPI::Mojolicious;
+
+use Mojo::Base 'JSON::Validator::OpenAPI';
+
+sub _extract_upload {
+  my ($self, $c, $name) = @_;
+
+  return $c->req->upload($name);
+}
+
+sub _extract_headers {
+  my ($self, $c) = @_;
+
+  return $c->res->headers;
+}
+
+sub _extract_request_parameter {
+  my ($self, $c, $in) = @_;
+
+  return $c->req->url->query->to_hash  if $in eq 'query';
+  return $c->match->stack->[-1]        if $in eq 'path';
+  return $c->req->body_params->to_hash if $in eq 'formData';
+  return $c->req->headers->to_hash     if $in eq 'header';
+  return $c->req->json                 if $in eq 'body';
+  return {};
+
+}
+
+sub _set_request_parameter {
+  my ($self, $c, $p, $value) = @_;
+  my ($in, $name) = @$p{qw(in name)};
+
+  if ($in eq 'query') {
+    $c->req->url->query([$name => $value]);
+    $c->req->params->merge($name => $value);
+  }
+  elsif ($in eq 'path') {
+    $c->stash($name => $value);
+  }
+  elsif ($in eq 'formData') {
+    $c->req->params->merge($name => $value);
+    $c->req->body_params->merge($name => $value);
+  }
+  elsif ($in eq 'header') {
+    $c->req->headers->header($name => $value);
+  }
+  elsif ($in eq 'body') {
+    return;    # no need to write body back
+  }
+  else {
+    die
+      "Cannot set default for $in => $name. Please submit a ticket here: https://github.com/jhthorsen/mojolicious-plugin-openapi";
+  }
+}
+
+1;

--- a/lib/JSON/Validator/OpenAPI/Mojolicious.pm
+++ b/lib/JSON/Validator/OpenAPI/Mojolicious.pm
@@ -2,33 +2,27 @@ package JSON::Validator::OpenAPI::Mojolicious;
 
 use Mojo::Base 'JSON::Validator::OpenAPI';
 
-sub _extract_upload {
-  my ($self, $c, $name) = @_;
+### request ###
 
-  return $c->req->upload($name);
-}
-
-sub _extract_headers {
-  my ($self, $c) = @_;
-
-  return $c->res->headers;
-}
-
-sub _extract_request_parameter {
+sub _get_request_data {
   my ($self, $c, $in) = @_;
 
-  return $c->req->url->query->to_hash  if $in eq 'query';
-  return $c->match->stack->[-1]        if $in eq 'path';
-  return $c->req->body_params->to_hash if $in eq 'formData';
-  return $c->req->headers->to_hash     if $in eq 'header';
-  return $c->req->json                 if $in eq 'body';
-  return {};
-
+  return $c->req->url->query->to_hash(1)  if $in eq 'query';
+  return $c->match->stack->[-1]           if $in eq 'path';
+  return $c->req->body_params->to_hash(1) if $in eq 'formData';
+  return $c->req->headers->to_hash(1)     if $in eq 'header';
+  return $c->req->body                    if $in eq 'body';
+  return {};    # TODO correct?
 }
 
-sub _set_request_parameter {
-  my ($self, $c, $p, $value) = @_;
-  my ($in, $name) = @$p{qw(in name)};
+sub _get_request_uploads {
+  my ($self, $c, $name) = @_;
+
+  return $c->req->every_upload($name);
+}
+
+sub _set_request_data {
+  my ($self, $c, $in, $name => $value) = @_;
 
   if ($in eq 'query') {
     $c->req->url->query([$name => $value]);
@@ -44,13 +38,29 @@ sub _set_request_parameter {
   elsif ($in eq 'header') {
     $c->req->headers->header($name => $value);
   }
-  elsif ($in eq 'body') {
-    return;    # no need to write body back
-  }
+  elsif ($in eq 'body') { }    # no need to write body back
   else {
     die
       "Cannot set default for $in => $name. Please submit a ticket here: https://github.com/jhthorsen/mojolicious-plugin-openapi";
   }
+}
+
+### response
+
+sub _get_response_data {
+  my ($self, $c, $in) = @_;
+
+  $in eq 'header' and return $c->res->headers->to_hash(1);
+
+  # TODO what else?
+}
+
+sub _set_response_data {
+  my ($self, $c, $in, $name => $value) = @_;
+
+  $in eq 'header' and $c->res->headers->header($name => ref $value ? @$value : $value);
+
+  # TODO what else?
 }
 
 1;

--- a/t/openapi-compatibility.t
+++ b/t/openapi-compatibility.t
@@ -1,0 +1,42 @@
+use Mojo::Base -strict;
+
+use File::Spec;
+use Mojo::Util;
+use Test::More tests => 3;
+
+ok(
+  module_calls_deprecated('JSON::Validator::OpenAPI'),
+  "JSON::Validator::OpenAPI->validate_request is deprecated"
+);
+
+ok(
+  !module_calls_deprecated('JSON::Validator::OpenAPI::Dancer2'),
+  "JSON::Validator::OpenAPI::Dancer2->validate_request isn't deprecated"
+);
+
+ok(
+  !module_calls_deprecated('JSON::Validator::OpenAPI::Mojolicious'),
+  "JSON::Validator::OpenAPI::Mojolicious->validate_request isn't deprecated"
+);
+
+sub module_calls_deprecated {
+  my $module = shift;
+
+  my $called = 0;
+  {
+    no warnings 'redefine';
+    *Mojo::Util::deprecated = sub { ++$called };
+  }
+
+  my $c      = {};
+  my $schema = {parameters => [{name => 'foo', in => 'query', type => 'integer'}]};
+  my $input  = {};
+
+  eval "require $module" or die $@;
+
+  eval {    # we don't care if this actually works out
+    $module->new->validate_request($c, $schema, $input);
+  };
+
+  return $called;
+}

--- a/t/openapi-formats.t
+++ b/t/openapi-formats.t
@@ -1,8 +1,8 @@
 use Mojo::Base -strict;
 use Test::More;
-use JSON::Validator::OpenAPI;
+use JSON::Validator::OpenAPI::Mojolicious;
 
-my $validator = JSON::Validator::OpenAPI->new;
+my $validator = JSON::Validator::OpenAPI::Mojolicious->new;
 my $schema = {type => 'object', properties => {v => {type => 'string'}}};
 my @errors;
 

--- a/t/openapi-request.t
+++ b/t/openapi-request.t
@@ -3,12 +3,12 @@ use Test::Mojo;
 use Test::More;
 use Mojo::JSON qw(false true);
 use Mojolicious::Controller;
-use JSON::Validator::OpenAPI;
+use JSON::Validator::OpenAPI::Mojolicious;
 
 my $t = Test::Mojo->new;
 my $c = Mojolicious::Controller->new(tx => Mojo::Transaction::HTTP->new);
 
-my $openapi = JSON::Validator::OpenAPI->new;
+my $openapi = JSON::Validator::OpenAPI::Mojolicious->new;
 my $input   = {};
 
 # formData

--- a/t/openapi-response.t
+++ b/t/openapi-response.t
@@ -3,12 +3,12 @@ use Test::Mojo;
 use Test::More;
 use Mojo::JSON qw(false true);
 use Mojolicious::Controller;
-use JSON::Validator::OpenAPI;
+use JSON::Validator::OpenAPI::Mojolicious;
 
 my $t = Test::Mojo->new;
 my $c = Mojolicious::Controller->new(tx => Mojo::Transaction::HTTP->new);
 
-my $openapi = JSON::Validator::OpenAPI->new;
+my $openapi = JSON::Validator::OpenAPI::Mojolicious->new;
 my ($schema, @errors);
 
 {

--- a/t/openapi.t
+++ b/t/openapi.t
@@ -1,14 +1,14 @@
 use Mojo::Base -strict;
 use Test::Mojo;
 use Test::More;
-use JSON::Validator::OpenAPI;
+use JSON::Validator::OpenAPI::Mojolicious;
 
 {
   local $TODO = 'Need to be updated to openapi spec';
   is JSON::Validator::OpenAPI::SPECIFICATION_URL(), 'http://swagger.io/v2/schema.json', 'spec url';
 }
 
-my $openapi = JSON::Validator::OpenAPI->new;
+my $openapi = JSON::Validator::OpenAPI::Mojolicious->new;
 my ($schema, @errors);
 
 # standard


### PR DESCRIPTION
Initially implements Mojolicious (based on existing code) and Dancer2.