### PR TITLE
Workaround bug with int params ending with chars

### DIFF
--- a/lib/JSON/Validator/OpenAPI.pm
+++ b/lib/JSON/Validator/OpenAPI.pm
@@ -71,7 +71,7 @@ sub validate_request {
     }
 
     if ($type and defined($value //= $p->{default})) {
-      if (($type eq 'integer' or $type eq 'number') and $value =~ /^-?\d/) {
+      if (($type eq 'integer' or $type eq 'number') and _is_number($value)) {
         $value += 0;
       }
       elsif ($type eq 'boolean') {

--- a/lib/JSON/Validator/OpenAPI.pm
+++ b/lib/JSON/Validator/OpenAPI.pm
@@ -71,7 +71,7 @@ sub validate_request {
     }
 
     if ($type and defined($value //= $p->{default})) {
-      if (($type eq 'integer' or $type eq 'number') and _is_number($value)) {
+      if (($type eq 'integer' or $type eq 'number') and _is_number($value, 'l')) {
         $value += 0;
       }
       elsif ($type eq 'boolean') {


### PR DESCRIPTION
A path /document/{id} thats requires an integer could give a
warning and pass validation given a value such as "42a". This
switches the number validation routine used so it fails validation
for being a string.

https://github.com/jhthorsen/json-validator/issues/36