### PR TITLE
Remove use of Carp::Always in deep ref test.

### DIFF
--- a/t/deep-mixed-ref.t
+++ b/t/deep-mixed-ref.t
@@ -2,8 +2,6 @@ use Mojo::Base -strict;
 use Test::More;
 use JSON::Validator;
 
-use Carp::Always;
-
 my $file
   = File::Spec->catfile(File::Basename::dirname(__FILE__), 'spec', 'with-deep-mixed-ref.json');
 my $validator = JSON::Validator->new(cache_paths => [])->schema($file);


### PR DESCRIPTION
Remove use of undeclared test dependency. Resolves #46