### PR TITLE
Allow alternative date-time separator

### DIFF
--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -719,8 +719,12 @@ sub _guessed_right {
 }
 
 sub _is_date_time {
-  $_[0] =~ qr/^(\d+)-(\d+)-(\d+)T(\d+):(\d+):(\d+(?:\.\d+)?)(?:Z|([+-])(\d+):(\d+))?$/io;
+  $_[0] =~ qr/
+    ^(\d+)-(\d+)-(\d+)\D+(\d+):(\d+):(\d+(?:\.\d+)?)   # Date and time
+    (?:Z|([+-])(\d+):(\d+))?$                          # Offset
+  /xi;
 }
+
 sub _is_domain { warn "Data::Validate::Domain is not installed"; return; }
 
 sub _is_email {

--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -720,8 +720,8 @@ sub _guessed_right {
 
 sub _is_date_time {
   $_[0] =~ qr/
-    ^\d+-\d+-\d+\D+\d+:\d+:\d+(?:\.\d+)?   # Date and time
-    (?:Z|[+-]\d+:\d+)?$                    # Offset
+    ^\d{4}-\d{2}-\d{2}.\d{2}:\d{2}:\d{2}(?:\.\d+)? # Date and time
+    (?:Z|[+-]\d{2}:\d{2})?$                        # Offset
   /xi;
 }
 

--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -720,8 +720,8 @@ sub _guessed_right {
 
 sub _is_date_time {
   $_[0] =~ qr/
-    ^(\d+)-(\d+)-(\d+)\D+(\d+):(\d+):(\d+(?:\.\d+)?)   # Date and time
-    (?:Z|([+-])(\d+):(\d+))?$                          # Offset
+    ^\d+-\d+-\d+\D+\d+:\d+:\d+(?:\.\d+)?   # Date and time
+    (?:Z|[+-]\d+:\d+)?$                    # Offset
   /xi;
 }
 

--- a/t/jv-formats.t
+++ b/t/jv-formats.t
@@ -10,6 +10,10 @@ my @errors;
   $schema->{properties}{v}{format} = 'date-time';
   @errors = $validator->validate({v => '2014-12-09T20:49:37Z'}, $schema);
   is "@errors", "", "date-time valid";
+  @errors = $validator->validate({v => '2014-12-09 20:49:37Z'}, $schema);
+  is "@errors", "", "date-time with alternate separator valid";
+  @errors = $validator->validate({v => '2014-12-09T20:49:37.00Z'}, $schema);
+  is "@errors", "", "date-time with fractional seconds valid";
   @errors = $validator->validate({v => '20:46:02'}, $schema);
   is "@errors", "/v: Does not match date-time format.", "date-time invalid";
 }


### PR DESCRIPTION
RFC3339 optionally allows the date and time separator 'T' to be
anything. This changes the previous date-time regex to the one
used by Mojo::Date, so cases like '2014-12-09 20:49:37Z' are
not rejected.

See: https://github.com/kraih/mojo/blob/master/lib/Mojo/Date.pm#L9
See: https://github.com/jhthorsen/json-validator/issues/48