### PR TITLE
_resolve_schema sometimes unintentionally skips an unresolved $ref

### DIFF
--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -258,7 +258,10 @@ sub _resolve_schema {
 
         # int($v) returns the memory address of the reference. The "if" below
         # will not resolve the same "$ref" over again.
-        next if ref $v and $self->{seen}{int($v)}++;
+        next if ref $v and $self->{seen}{int($v)};
+        # Store the reference to keep that memory address in use for that
+        # particular reference.
+        $self->{seen}{int($v)} = $v if ref $v;
 
         # Make sure we do not modify the input data structure.
         # Changing the input makes t/expand.t in swagger2.git fail.

--- a/t/openapi-unresolved-ref.t
+++ b/t/openapi-unresolved-ref.t
@@ -1,0 +1,34 @@
+use Mojo::Base -strict;
+use Test::More;
+use JSON::Validator::OpenAPI;
+use Data::Dumper;
+
+#for my $i (1..20) {
+my $validator = JSON::Validator::OpenAPI->new->load_and_validate_spec(
+    't/spec/koha-swagger/swagger.json',
+    {
+        allow_invalid_ref => 1
+    }
+);
+
+is(for_hash($validator->schema->{data}), 0, 'No $refs unresolved.');
+#}
+
+sub for_hash {
+    my ($hash) = @_;
+    while (my ($key, $value) = each %$hash) {
+        if ('HASH' eq ref $value) {
+            my $ret = for_hash($value);
+            if ($ret) {
+                return $ret;
+            }
+        }
+        else {
+            if ($key eq '$ref') {
+                return $value;
+            }
+        }
+    }
+}
+
+done_testing;

--- a/t/spec/koha-swagger/definitions.json
+++ b/t/spec/koha-swagger/definitions.json
@@ -1,0 +1,59 @@
+{
+  "accountline": {
+    "$ref": "definitions/accountline.json"
+  },
+  "availability": {
+    "$ref": "definitions/availability.json"
+  },
+  "availability/biblio": {
+    "$ref": "definitions/availability/biblio.json"
+  },
+  "availability/item": {
+    "$ref": "definitions/availability/item.json"
+  },
+  "city": {
+    "$ref": "definitions/city.json"
+  },
+  "patron": {
+    "$ref": "definitions/patron.json"
+  },
+  "patronstatus": {
+    "$ref": "definitions/patronstatus.json"
+  },
+  "session": {
+    "$ref": "definitions/session.json"
+  },
+  "checkouts": {
+    "$ref": "definitions/checkouts.json"
+  },
+  "checkout": {
+    "$ref": "definitions/checkout.json"
+  },
+  "holds": {
+    "$ref": "definitions/holds.json"
+  },
+  "hold": {
+    "$ref": "definitions/hold.json"
+  },
+  "item": {
+    "$ref": "definitions/item.json"
+  },
+  "libraries": {
+    "$ref": "definitions/libraries.json"
+  },
+  "library": {
+    "$ref": "definitions/library.json"
+  },
+  "error": {
+    "$ref": "definitions/error.json"
+  },
+  "biblios": {
+    "$ref": "definitions/biblios.json"
+  },
+  "biblio": {
+    "$ref": "definitions/biblio.json"
+  },
+  "renewability": {
+    "$ref": "definitions/renewability.json"
+  }
+}

--- a/t/spec/koha-swagger/definitions/accountline.json
+++ b/t/spec/koha-swagger/definitions/accountline.json
@@ -1,0 +1,75 @@
+{
+  "type": "object",
+  "properties": {
+    "accountlines_id": {
+      "type": "integer",
+      "description": "Internal account line identifier"
+    },
+    "issue_id": {
+      "type": ["integer", "null"],
+      "description": "?"
+    },
+    "borrowernumber": {
+      "type": "integer",
+      "description": "Internal borrower identifier"
+    },
+    "accountno": {
+      "type": "integer",
+      "description": "?"
+    },
+    "itemnumber": {
+      "type": ["integer", "null"],
+      "description": "Internal item identifier"
+    },
+    "date": {
+      "type": ["string", "null"],
+      "description": "Date when the account line was created",
+      "format": "date"
+    },
+    "amount": {
+      "type": ["number", "null"],
+      "description": "Amount"
+    },
+    "description": {
+      "type": ["string", "null"],
+      "description": "Description of account line"
+    },
+    "dispute": {
+      "type": ["string", "null"],
+      "description": "?"
+    },
+    "accounttype": {
+      "type": ["string", "null"],
+      "description": "Type of accountline"
+    },
+    "amountoutstanding": {
+      "type": ["number", "null"],
+      "description": "Amount outstanding"
+    },
+    "lastincrement": {
+      "type": ["number", "null"],
+      "description": "?"
+    },
+    "timestamp": {
+      "type": "string",
+      "description": "When the account line was last updated",
+      "format": "date-time"
+    },
+    "notify_id": {
+      "type": "integer",
+      "description": "?"
+    },
+    "notify_level": {
+      "type": "integer",
+      "description": "?"
+    },
+    "note": {
+      "type": ["string", "null"],
+      "description": "Accountline note"
+    },
+    "manager_id": {
+      "type": ["integer", "null"],
+      "description": "Borrowernumber of user that created the account line"
+    }
+  }
+}

--- a/t/spec/koha-swagger/definitions/availability.json
+++ b/t/spec/koha-swagger/definitions/availability.json
@@ -1,0 +1,18 @@
+{
+  "type": "object",
+  "properties": {
+    "available": {
+      "type": "boolean",
+      "description": "Availability status"
+    },
+    "confirmations": {
+      "$ref": "./availability/reason.json"
+    },
+    "notes": {
+      "$ref": "./availability/reason.json"
+    },
+    "unavailabilities": {
+      "$ref": "./availability/reason.json"
+    }
+  }
+}

--- a/t/spec/koha-swagger/definitions/availability/biblio.json
+++ b/t/spec/koha-swagger/definitions/availability/biblio.json
@@ -1,0 +1,19 @@
+{
+  "type": "object",
+  "properties": {
+    "biblionumber": {
+      "type": "integer",
+      "description": "Internal biblio identifier"
+    },
+    "availability": {
+      "$ref": "../availability.json"
+    },
+    "item_availabilities": {
+      "description": "Availability of each item in this biblio",
+      "type": ["array", "null"],
+      "items": {
+        "$ref": "../availability/item.json"
+      }
+    }
+  }
+}

--- a/t/spec/koha-swagger/definitions/availability/item.json
+++ b/t/spec/koha-swagger/definitions/availability/item.json
@@ -1,0 +1,52 @@
+{
+  "type": "object",
+  "properties": {
+    "availability": {
+      "$ref": "../availability.json"
+    },
+    "barcode": {
+      "type": ["string", "null"],
+      "description": "item barcode"
+    },
+    "biblioitemnumber": {
+      "type": "integer",
+      "description": "internally assigned biblio item identifier"
+    },
+    "biblionumber": {
+      "type": "integer",
+      "description": "internally assigned biblio identifier"
+    },
+    "enumchron": {
+      "type": ["string", "null"],
+      "description": "serial enumeration/chronology for the item"
+    },
+    "holdQueueLength": {
+      "type": ["integer", "null"],
+      "description": "number of holdings placed on title/item"
+    },
+    "holdingbranch": {
+      "type": ["string", "null"],
+      "description": "library that is currently in possession item"
+    },
+    "homebranch": {
+      "type": ["string", "null"],
+      "description": "library that owns this item"
+    },
+    "itemcallnumber": {
+      "type": ["string", "null"],
+      "description": "call number for this item"
+    },
+    "itemnotes": {
+      "type": ["string", "null"],
+      "description": "public notes on this item"
+    },
+    "itemnumber": {
+      "type": "integer",
+      "description": "internally assigned item identifier"
+    },
+    "location": {
+      "type": ["string", "null"],
+      "description": "authorized value for the shelving location for this item"
+    }
+  }
+}

--- a/t/spec/koha-swagger/definitions/availability/reason.json
+++ b/t/spec/koha-swagger/definitions/availability/reason.json
@@ -1,0 +1,404 @@
+{
+  "description": "An object that contains either none or multiple reasons defined in this object's specification.",
+  "type": "object",
+  "properties": {
+    "Biblio::CheckedOut": {
+      "description": "Patron has already checked out an item from this biblio. A confirmation may be required.",
+      "type": "object",
+      "properties": {
+        "biblionumber": {
+          "$ref": "../../x-primitives.json#/biblionumber"
+        }
+      }
+    },
+    "Biblio::NoAvailableItems": {
+      "description": "This biblio has no available items.",
+      "type": "object",
+      "properties": {}
+    },
+    "Checkout::DueDateBeforeNow": {
+      "description": "Given due date is in the past.",
+      "type": "object",
+      "properties": {
+        "duedate": {
+          "type": ["string", "null"],
+          "format": "date-time"
+        },
+        "now": {
+          "type": ["string", "null"],
+          "format": "date-time"
+        }
+      }
+    },
+    "Checkout::Fee": {
+      "description": "Checkout fee will apply.",
+      "type": "object",
+      "properties": {
+        "amount": {
+          "type": ["number", "null"],
+          "description": "Amount of rental charge."
+        }
+      }
+    },
+    "Checkout::InvalidDueDate": {
+      "description": "Given due date is invalid.",
+      "type": "object",
+      "properties": {
+        "duedate": {
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "Checkout::MaximumCheckoutsReached": {
+      "description": "Maximum number of checkouts have been reached.",
+      "type": "object",
+      "properties": {
+        "max_checkouts_allowed": {
+          "type": ["integer", "null"],
+          "description": "Maximum number of checkouts allowed."
+        },
+        "current_checkout_count": {
+          "type": ["integer", "null"],
+          "description": "Current checkout count for patron."
+        }
+      }
+    },
+    "Checkout::MaximumOnsiteCheckoutsReached": {
+      "description": "Maximum number of on-site checkouts have been reached.",
+      "type": "object",
+      "properties": {
+        "max_onsite_checkouts": {
+          "type": ["integer", "null"],
+          "description": "Maximum number of onsite checkouts allowed."
+        },
+        "current_onsite_checkouts": {
+          "type": ["integer", "null"],
+          "description": "Current onsite checkout count for patron."
+        }
+      }
+    },
+    "Checkout::NoMoreRenewals": {
+      "description": "No more renewals allowed.",
+      "type": "object",
+      "properties": {}
+    },
+    "Checkout::NoMoreRenewalForOnsiteCheckouts": {
+      "description": "No more on-site renewals allowed.",
+      "type": "object",
+      "properties": {}
+    },
+    "Checkout::OnsiteCheckoutsDisabled": {
+      "description": "On-site checkouts are disabled.",
+      "type": "object",
+      "properties": {}
+    },
+    "Checkout::Renew": {
+      "description": "Checkout will be renewed.",
+      "type": "object",
+      "properties": {}
+    },
+    "Checkout::ZeroCheckoutsAllowed": {
+      "description": "Allowed number of checkouts is zero.",
+      "type": "object",
+      "properties": {}
+    },
+    "Hold::ItemLevelHoldNotAllowed": {
+      "description": "Item-level holds are not allowed.",
+      "type": "object",
+      "properties": {}
+    },
+    "Hold::MaximumHoldsReached": {
+      "description": "Maximum number of holds have been reached.",
+      "type": "object",
+      "properties": {
+        "max_holds_allowed": {
+          "type": ["integer", "null"]
+        },
+        "current_hold_count": {
+          "type": ["integer", "null"]
+        }
+      }
+    },
+    "Hold::MaximumHoldsForThisRecordReached": {
+      "description": "Maximum number of holds for this record have been reached.",
+      "type": "object",
+      "properties": {
+        "max_holds_allowed": {
+          "type": ["integer", "null"]
+        },
+        "current_hold_count": {
+          "type": ["integer", "null"]
+        }
+      }
+    },
+    "Hold::NotAllowedByLibrary": {
+      "description": "Library does not allow holds to be placed.",
+      "type": "object",
+      "properties": {}
+    },
+    "Hold::NotAllowedFromOtherLibraries": {
+      "description": "Holds are not allowed from other libraries.",
+      "type": "object",
+      "properties": {}
+    },
+    "Hold::NotAllowedInOPAC": {
+      "description": "Patron cannot place a hold by themselves in OPAC.",
+      "type": "object",
+      "properties": {}
+    },
+    "Hold::OnShelfNotAllowed": {
+      "description": "On-shelf holds are not allowed.",
+      "type": "object",
+      "properties": {}
+    },
+    "Hold::ZeroHoldsAllowed": {
+      "description": "Allowed number of holds is zero.",
+      "type": "object",
+      "properties": {}
+    },
+    "Item::AlreadyHeldForThisPatron": {
+      "description": "Item is held for this patron.",
+      "type": "object",
+      "properties": {}
+    },
+    "Item::CannotBeTransferred": {
+      "description": "Item cannot be transferred.",
+      "type": "object",
+      "properties": {
+        "from_library": {
+          "$ref": "../../x-primitives.json#/branchcode"
+        },
+        "to_library": {
+          "$ref": "../../x-primitives.json#/branchcode"
+        }
+      }
+    },
+    "Item::CheckedOut": {
+      "description": "Item is checked out to a patron.",
+      "type": "object",
+      "properties": {
+        "borrowernumber": {
+          "type": ["integer", "null"]
+        },
+        "date_due": {
+          "type": ["string", "null"],
+          "format": "date-time"
+        }
+      }
+    },
+    "Item::Damaged": {
+      "description": "Item is marked as damaged",
+      "type": "object",
+      "properties": {}
+    },
+    "Item::FromAnotherLibrary": {
+      "description": "Libraries are independent and this item is from another library than current patron.",
+      "type": "object",
+      "properties": {
+        "itemhomebranch": {
+          "$ref": "../../x-primitives.json#/branchcode"
+        }
+      }
+    },
+    "Item::Held": {
+      "description": "Someone has placed a hold on this item.",
+      "type": "object",
+      "properties": {
+        "borrowernumber": {
+          "$ref": "../../x-primitives.json#/borrowernumber"
+        },
+        "status": {
+          "type": ["string", "null"]
+        },
+        "hold_queue_length": {
+          "type": ["integer", "null"]
+        }
+      }
+    },
+    "Item::HighHolds": {
+      "description": "Loan period shortened for high held item.",
+      "type": "object",
+      "properties": {
+        "num_holds": {
+          "type": ["integer", "null"]
+        },
+        "duration": {
+          "type": ["string", "null"]
+        },
+        "returndate": {
+          "type": ["string", "null"],
+          "format": "date-time"
+        }
+      }
+    },
+    "Item::Lost": {
+      "description": "Item is marked as lost.",
+      "type": "object",
+      "properties": {
+        "code": {
+          "description": "Status description (e.g. Missing)",
+          "type": ["string", "null"]
+        },
+        "status": {
+          "description": "Item's lost status number",
+          "type": ["integer", "null"]
+        }
+      }
+    },
+    "Item::NotForLoan": {
+      "description": "Item is not for loan.",
+      "type": "object",
+      "properties": {
+        "status": {
+          "description": "Item's notforloan status number",
+          "type": ["integer", "null"]
+        },
+        "code": {
+          "description": "Status description (e.g. Ordered)",
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "Item::Restricted": {
+      "description": "Item is restricted.",
+      "type": "object",
+      "properties": {}
+    },
+    "Item::Transfer": {
+      "description": "Item is being transferred.",
+      "type": "object",
+      "properties": {
+        "from_library": {
+          "$ref": "../../x-primitives.json#/branchcode"
+        },
+        "to_library": {
+          "$ref": "../../x-primitives.json#/branchcode"
+        },
+        "datesent": {
+          "description": "Start date of transfer",
+          "type": ["string", "null"],
+          "format": "date-time"
+        }
+      }
+    },
+    "Item::UnknownBarcode": {
+      "description": "This item has either an unknown barcode or no barcode at all.",
+      "type": "object",
+      "properties": {
+        "barcode": {
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "Item::Withdrawn": {
+      "description": "Item is withdrawn.",
+      "type": "object",
+      "properties": {}
+    },
+    "ItemType::NotForLoan": {
+      "description": "Item type is not for loan.",
+      "type": "object",
+      "properties": {
+        "status": {
+          "description": "Item's notforloan status number",
+          "type": ["integer", "null"]
+        },
+        "code": {
+          "description": "Status description (e.g. Ordered)",
+          "type": ["string", "null"]
+        },
+        "itemtype": {
+          "description": "Item type",
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "Patron::AgeRestricted": {
+      "description": "An age restriction applies for this patron.",
+      "type": "object",
+      "properties": {
+        "age_restriction": {
+          "type": ["string", "null"],
+          "description": "Age restriction, e.g. PEGI 16"
+        }
+      }
+    },
+    "Patron::CardExpired": {
+      "description": "Patron's card has been expired.",
+      "type": "object",
+      "properties": {
+        "expiration_date": {
+          "type": ["string", "null"],
+          "format": "date"
+        }
+      }
+    },
+    "Patron::CardLost": {
+      "description": "Patron's card has been marked as lost.",
+      "type": "object",
+      "properties": {}
+    },
+    "Patron::Debarred": {
+      "description": "Patron is debarred.",
+      "type": "object",
+      "properties": {
+        "expiration_date": {
+          "type": ["string", "null"],
+          "format": "date"
+        },
+        "comment": {
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "Patron::DebarredOverdue": {
+      "description": "Patron has overdues and is debarred.",
+      "type": "object",
+      "properties": {
+        "number_of_overdues": {
+          "type": ["integer", "null"]
+        }
+      }
+    },
+    "Patron::Debt": {
+      "description": "Patron's debts exceed maximum allowed amount.",
+      "type": "object",
+      "properties": {
+        "max_outstanding":{
+          "type": ["number", "null"]
+        },
+        "current_outstanding": {
+          "type": ["number", "null"]
+        }
+      }
+    },
+    "Patron::DebtGuarantees": {
+      "description": "Patron's guarantees' debts exceed maximum allowed amount.",
+      "type": "object",
+      "properties": {
+        "max_outstanding":{
+          "type": ["number", "null"]
+        },
+        "current_outstanding": {
+          "type": ["number", "null"]
+        }
+      }
+    },
+    "Patron::FromAnotherLibrary": {
+      "description": "Libraries are independent and patron is from another library than current logged in user.",
+      "type": "object",
+      "properties": {
+        "patron_branch": {
+          "$ref": "../../x-primitives.json#/branchcode"
+        },
+        "current_branch": {
+          "$ref": "../../x-primitives.json#/branchcode"
+        }
+      }
+    },
+    "Patron::GoneNoAddress": {
+      "type": "object",
+      "properties": {}
+    }
+  }
+}

--- a/t/spec/koha-swagger/definitions/biblio.json
+++ b/t/spec/koha-swagger/definitions/biblio.json
@@ -1,0 +1,54 @@
+{
+  "type": "object",
+    "properties": {
+    "biblionumber": {
+      "$ref": "../x-primitives.json#/biblionumber"
+    },
+    "author": {
+      "type": ["string", "null"],
+      "description": "statement of responsibility from MARC record (100$a in MARC21)"
+    },
+    "title": {
+      "type": ["string", "null"],
+      "description": "title (without the subtitle) from the MARC record (245$a in MARC21)"
+    },
+    "unititle": {
+      "type": ["string", "null"],
+      "description": "uniform title (without the subtitle) from the MARC record (240$a in MARC21)"
+    },
+    "notes": {
+      "type": ["string", "null"],
+      "description": "values from the general notes field in the MARC record (500$a in MARC21) split by bar (|)"
+    },
+    "serial": {
+      "type": ["integer", "null"],
+      "description": "Boolean indicating whether biblio is for a serial"
+    },
+    "seriestitle": {
+      "type": ["string", "null"],
+      "description": ""
+    },
+    "copyrightdate": {
+      "type": ["integer", "null"],
+      "description": "publication or copyright date from the MARC record"
+    },
+    "timestamp": {
+      "type": "string",
+      "description": "date and time this record was last touched",
+      "format": "date-time"
+    },
+    "datecreated": {
+      "type": "string",
+      "description": "the date this record was added to Koha",
+      "format": "date"
+    },
+    "abstract": {
+      "type": ["string", "null"],
+      "description": "summary from the MARC record (520$a in MARC21)"
+    },
+    "frameworkcode": {
+      "type": "string",
+      "description": "framework used in cataloging this record"
+    }
+  }
+}

--- a/t/spec/koha-swagger/definitions/biblios.json
+++ b/t/spec/koha-swagger/definitions/biblios.json
@@ -1,0 +1,4 @@
+{
+    "type": "array",
+    "items": { "$ref": "biblio.json" }
+}

--- a/t/spec/koha-swagger/definitions/checkout.json
+++ b/t/spec/koha-swagger/definitions/checkout.json
@@ -1,0 +1,65 @@
+{
+  "type": "object",
+  "properties": {
+    "issue_id": {
+      "type": "integer",
+      "description": "internally assigned checkout identifier"
+    },
+    "borrowernumber": {
+      "type": ["integer", "null"],
+      "description": "internally assigned user identifier"
+    },
+    "itemnumber": {
+      "type": ["integer", "null"],
+      "description": "internally assigned item identifier"
+    },
+    "date_due": {
+      "type": ["string", "null"],
+      "description": "Due date",
+      "format": "date-time"
+    },
+    "branchcode": {
+      "type": ["string", "null"],
+      "description": "code of patron's home branch"
+    },
+    "issuingbranch": {
+      "description": "Code of the branch where issue was made"
+    },
+    "returndate": {
+      "type": ["string", "null"],
+      "description": "Date the item was returned",
+      "format": "date-time"
+    },
+    "lastreneweddate": {
+      "type": ["string", "null"],
+      "description": "Date the item was last renewed",
+      "format": "date-time"
+    },
+    "return": {
+      "type": ["string", "null"],
+      "description": "?"
+    },
+    "renewals": {
+      "type": ["integer", "null"],
+      "description": "Number of renewals"
+    },
+    "auto_renew": {
+      "type": ["integer", "null"],
+      "description": "Auto renewal"
+    },
+    "timestamp": {
+      "type": "string",
+      "description": "Last update time",
+      "format": "date-time"
+    },
+    "issuedate": {
+      "type": ["string", "null"],
+      "description": "Date the item was issued",
+      "format": "date-time"
+    },
+    "onsite_checkout": {
+      "type": "integer",
+      "description": "On site checkout"
+    }
+  }
+}

--- a/t/spec/koha-swagger/definitions/checkouts.json
+++ b/t/spec/koha-swagger/definitions/checkouts.json
@@ -1,0 +1,6 @@
+{
+  "type": "array",
+  "items": {
+    "$ref": "checkout.json"
+  }
+}

--- a/t/spec/koha-swagger/definitions/city.json
+++ b/t/spec/koha-swagger/definitions/city.json
@@ -1,0 +1,26 @@
+{
+  "type": "object",
+  "properties": {
+    "cityid": {
+      "$ref": "../x-primitives.json#/cityid"
+    },
+    "city_name": {
+      "description": "city name",
+      "type": "string"
+    },
+    "city_state": {
+      "description": "city state",
+      "type": ["string", "null"]
+    },
+    "city_zipcode": {
+      "description": "city zipcode",
+      "type": ["string", "null"]
+    },
+    "city_country": {
+      "description": "city country",
+      "type": ["string", "null"]
+    }
+  },
+  "additionalProperties": false,
+  "required": ["city_name", "city_state", "city_zipcode", "city_country"]
+}

--- a/t/spec/koha-swagger/definitions/error.json
+++ b/t/spec/koha-swagger/definitions/error.json
@@ -1,0 +1,9 @@
+{
+  "type": "object",
+  "properties": {
+    "error": {
+      "description": "Error message",
+      "type": "string"
+    }
+  }
+}

--- a/t/spec/koha-swagger/definitions/hold.json
+++ b/t/spec/koha-swagger/definitions/hold.json
@@ -1,0 +1,86 @@
+{
+  "type": "object",
+  "properties": {
+    "reserve_id": {
+      "$ref": "../x-primitives.json#/reserve_id"
+    },
+    "borrowernumber": {
+      "$ref": "../x-primitives.json#/borrowernumber"
+    },
+    "reservedate": {
+      "type": ["string", "null"],
+      "description": "the date the hold was placed",
+      "format": "date"
+    },
+    "biblionumber": {
+      "$ref": "../x-primitives.json#/biblionumber"
+    },
+    "branchcode": {
+      "type": ["string", "null"],
+      "description": "code of patron's home branch"
+    },
+    "notificationdate": {
+      "type": ["string", "null"],
+      "description": "currently unused",
+      "format": "date"
+    },
+    "reminderdate": {
+      "type": ["string", "null"],
+      "description": "currently unused",
+      "format": "date"
+    },
+    "cancellationdate": {
+      "type": ["string", "null"],
+      "description": "the date the hold was cancelled",
+      "format": "date"
+    },
+    "reservenotes": {
+      "type": ["string", "null"],
+      "description": "notes related to this hold"
+    },
+    "priority": {
+      "type": ["integer", "null"],
+      "description": "where in the queue the patron sits"
+    },
+    "found": {
+      "type": ["string", "null"],
+      "description": "a one letter code defining what the status of the hold is after it has been confirmed"
+    },
+    "timestamp": {
+      "type": ["string", "null"],
+      "description": "date and time the hold was last updated",
+      "format": "date-time"
+    },
+    "itemnumber": {
+      "type": ["integer", "null"],
+      "description": "foreign key from the items table defining the specific item the patron has placed on hold or the item this hold was filled with"
+    },
+    "waitingdate": {
+      "type": ["string", "null"],
+      "description": "the date the item was marked as waiting for the patron at the library",
+      "format": "date"
+    },
+    "expirationdate": {
+      "type": ["string", "null"],
+      "description": "the date the hold expires",
+      "format": "date"
+    },
+    "lowestPriority": {
+      "type": "boolean",
+      "description": ""
+    },
+    "suspend": {
+      "type": "boolean",
+      "description": ""
+    },
+    "suspend_until": {
+      "type": ["string", "null"],
+      "description": "",
+      "format": "date-time"
+    },
+    "itemtype": {
+      "type": ["string", "null"],
+      "description": "If record level hold, the optional itemtype of the item the patron is requesting"
+    }
+  }
+}

--- a/t/spec/koha-swagger/definitions/holds.json
+++ b/t/spec/koha-swagger/definitions/holds.json
@@ -1,0 +1,6 @@
+{
+  "type": "array",
+  "items": {
+    "$ref": "hold.json"
+  }
+}

--- a/t/spec/koha-swagger/definitions/item.json
+++ b/t/spec/koha-swagger/definitions/item.json
@@ -1,0 +1,189 @@
+{
+  "type": "object",
+  "properties": {
+    "itemnumber": {
+      "type": "integer",
+      "description": "internally assigned item identifier"
+    },
+    "biblionumber": {
+      "type": "integer",
+      "description": "internally assigned biblio identifier"
+    },
+    "biblioitemnumber": {
+      "type": "integer",
+      "description": "internally assigned biblio item identifier"
+    },
+    "barcode": {
+      "type": ["string", "null"],
+      "description": "item barcode"
+    },
+    "dateaccessioned": {
+      "type": ["string", "null"],
+      "description": "date the item was acquired or added to Koha",
+      "format": "date"
+    },
+    "booksellerid": {
+      "type": ["string", "null"],
+      "description": "where the item was purchased"
+    },
+    "homebranch": {
+      "type": ["string", "null"],
+      "description": "library that owns this item"
+    },
+    "price": {
+      "type": ["number", "null"],
+      "description": "purchase price"
+    },
+    "replacementprice": {
+      "type": ["number", "null"],
+      "description": "cost the library charges to replace the item if it has been marked lost"
+    },
+    "replacementpricedate": {
+      "type": ["string", "null"],
+      "description": "the date the price is effective from",
+      "format": "date"
+    },
+    "datelastborrowed": {
+      "type": ["string", "null"],
+      "description": "the date the item was last checked out/issued",
+      "format": "date"
+    },
+    "datelastseen": {
+      "type": ["string", "null"],
+      "description": "the date the item was last see (usually the last time the barcode was scanned or inventory was done)",
+      "format": "date"
+    },
+    "stack": {
+      "type": ["integer", "null"],
+      "description": "?"
+    },
+    "notforloan": {
+      "type": "integer",
+      "description": "authorized value defining why this item is not for loan"
+    },
+    "damaged": {
+      "type": "integer",
+      "description": "authorized value defining this item as damaged"
+    },
+    "itemlost": {
+      "type": "integer",
+      "description": "authorized value defining this item as lost"
+    },
+    "itemlost_on": {
+      "type": ["string", "null"],
+      "description": "the date and time an item was last marked as lost, NULL if not lost",
+      "format": "date-time"
+    },
+    "withdrawn": {
+      "type": "integer",
+      "description": "authorized value defining this item as withdrawn"
+    },
+    "withdrawn_on": {
+      "type": ["string", "null"],
+      "description": "the date and time an item was last marked as withdrawn, NULL if not withdrawn",
+      "format": "date-time"
+    },
+    "itemcallnumber": {
+      "type": ["string", "null"],
+      "description": "call number for this item"
+    },
+    "coded_location_qualifier": {
+      "type": ["string", "null"],
+      "description": "coded location qualifier"
+    },
+    "issues": {
+      "type": ["integer", "null"],
+      "description": "number of times this item has been checked out/issued"
+    },
+    "renewals": {
+      "type": ["integer", "null"],
+      "description": "number of times this item has been renewed"
+    },
+    "reserves": {
+      "type": ["integer", "null"],
+      "description": "number of times this item has been placed on hold/reserved"
+    },
+    "restricted": {
+      "type": ["integer", "null"],
+      "description": "authorized value defining use restrictions for this item"
+    },
+    "itemnotes": {
+      "type": ["string", "null"],
+      "description": "public notes on this item"
+    },
+    "itemnotes_nonpublic": {
+      "type": ["string", "null"],
+      "description": "non-public notes on this item"
+    },
+    "holdingbranch": {
+      "type": ["string", "null"],
+      "description": "library that is currently in possession item"
+    },
+    "paidfor": {
+      "type": ["string", "null"],
+      "description": "?"
+    },
+    "timestamp": {
+      "type": "string",
+      "description": "date and time this item was last altered",
+      "format": "date-time"
+    },
+    "location": {
+      "type": ["string", "null"],
+      "description": "authorized value for the shelving location for this item"
+    },
+    "permanent_location": {
+      "type": ["string", "null"],
+      "description": "linked to the CART and PROC temporary locations feature, stores the permanent shelving location"
+    },
+    "onloan": {
+      "type": ["string", "null"],
+      "description": "defines if item is checked out (NULL for not checked out, and checkout date for checked out)",
+      "format": "date"
+    },
+    "cn_source": {
+      "type": ["string", "null"],
+      "description": "classification source used on this item"
+    },
+    "cn_sort": {
+      "type": ["string", "null"],
+      "description": "?"
+    },
+    "ccode": {
+      "type": ["string", "null"],
+      "description": "authorized value for the collection code associated with this item"
+    },
+    "materials": {
+      "type": ["string", "null"],
+      "description": "materials specified"
+    },
+    "uri": {
+      "type": ["string", "null"],
+      "description": "URL for the item"
+    },
+    "itype": {
+      "type": ["string", "null"],
+      "description": "itemtype defining the type for this item"
+    },
+    "more_subfields_xml": {
+      "type": ["string", "null"],
+      "description": "additional 952 subfields in XML format"
+    },
+    "enumchron": {
+      "type": ["string", "null"],
+      "description": "serial enumeration/chronology for the item"
+    },
+    "copynumber": {
+      "type": ["string", "null"],
+      "description": "copy number"
+    },
+    "stocknumber": {
+      "type": ["string", "null"],
+      "description": "inventory number"
+    },
+    "new_status": {
+      "type": ["string", "null"],
+      "description": "'new' value, whatever free-text information."
+    }
+  }
+}

--- a/t/spec/koha-swagger/definitions/libraries.json
+++ b/t/spec/koha-swagger/definitions/libraries.json
@@ -1,0 +1,6 @@
+{
+  "type": "array",
+  "items": {
+    "$ref": "library.json"
+  }
+}

--- a/t/spec/koha-swagger/definitions/library.json
+++ b/t/spec/koha-swagger/definitions/library.json
@@ -1,0 +1,89 @@
+{
+  "type": "object",
+  "properties": {
+    "branchcode": {
+      "type": "string",
+      "description": "a unique key assigned to each branch"
+    },
+    "branchname": {
+      "type": "string",
+      "description": "Printable name of library"
+    },
+    "branchaddress1": {
+      "type": [ "string", "null" ],
+      "description": "the first address line of the library"
+    },
+    "branchaddress2": {
+      "type": [ "string", "null" ],
+      "description": "the second address line of the library"
+    },
+    "branchaddress3": {
+      "type": [ "string", "null" ],
+      "description": "the third address line of the library"
+    },
+    "branchzip": {
+      "type": [ "string", "null" ],
+      "description": "the zip or postal code of the library"
+    },
+    "branchcity": {
+      "type": [ "string", "null" ],
+      "description": "the city or province of the library"
+    },
+    "branchstate": {
+      "type": [ "string", "null" ],
+      "description": "the reqional state of the library"
+    },
+    "branchcountry": {
+      "type": [ "string", "null" ],
+      "description": "the county of the library"
+    },
+    "branchphone": {
+      "type": [ "string", "null" ],
+      "description": "the primary phone of the library"
+    },
+    "branchfax": {
+      "type": [ "string", "null" ],
+      "description": "the fax number of the library"
+    },
+    "branchemail": {
+      "type": [ "string", "null" ],
+      "description": "the primary email address of the library"
+    },
+    "branchreplyto": {
+      "type": [ "string", "null" ],
+      "description": "the email to be used as a Reply-To"
+    },
+    "branchreturnpath": {
+      "type": [ "string", "null" ],
+      "description": "the email to be used as Return-Path"
+    },
+    "branchurl": {
+      "type": [ "string", "null" ],
+      "description": "the URL for your library or branch's website"
+    },
+    "branchip": {
+      "type": [ "string", "null" ],
+      "description": "the IP address for your library or branch"
+    },
+    "branchnotes": {
+      "type": [ "string", "null" ],
+      "description": "notes related to your library or branch"
+    },
+    "opac_info": {
+      "type": [ "string", "null" ],
+      "description": "HTML that displays in OPAC"
+    },
+    "branchprinter": {
+      "type": ["string", "null"],
+      "description": "?"
+    },
+    "issuing": {
+      "type": ["integer", "null"],
+      "description": "?"
+    },
+    "pickup_location": {
+      "type": "integer",
+      "description": "can your library be listed as a pickup location for holds"
+    }
+  }
+}

--- a/t/spec/koha-swagger/definitions/patron.json
+++ b/t/spec/koha-swagger/definitions/patron.json
@@ -1,0 +1,285 @@
+{
+  "type": "object",
+  "properties": {
+    "borrowernumber": {
+      "$ref": "../x-primitives.json#/borrowernumber"
+    },
+    "cardnumber": {
+      "$ref": "../x-primitives.json#/cardnumber"
+    },
+    "surname": {
+      "$ref": "../x-primitives.json#/surname"
+    },
+    "firstname": {
+      "$ref": "../x-primitives.json#/firstname"
+    },
+    "title": {
+      "type": ["string", "null"],
+      "description": "patron's title"
+    },
+    "othernames": {
+      "type": ["string", "null"],
+      "description": "any other names associated with the patron"
+    },
+    "initials": {
+      "type": ["string", "null"],
+      "description": "initials of the patron"
+    },
+    "streetnumber": {
+      "type": ["string", "null"],
+      "description": "street number of patron's primary address"
+    },
+    "streettype": {
+      "type": ["string", "null"],
+      "description": "street type of patron's primary address"
+    },
+    "address": {
+      "type": "string",
+      "description": "first address line of patron's primary address"
+    },
+    "address2": {
+      "type": ["string", "null"],
+      "description": "second address line of patron's primary address"
+    },
+    "city": {
+      "type": "string",
+      "description": "city or town of patron's primary address"
+    },
+    "state": {
+      "type": ["string", "null"],
+      "description": "state or province of patron's primary address"
+    },
+    "zipcode": {
+      "type": ["string", "null"],
+      "description": "zip or postal code of patron's primary address"
+    },
+    "country": {
+      "type": ["string", "null"],
+      "description": "country of patron's primary address"
+    },
+    "email": {
+      "$ref": "../x-primitives.json#/email"
+    },
+    "phone": {
+      "$ref": "../x-primitives.json#/phone"
+    },
+    "mobile": {
+      "type": ["string", "null"],
+      "description": "the other phone number for patron's primary address"
+    },
+    "fax": {
+      "type": ["string", "null"],
+      "description": "fax number for patron's primary address"
+    },
+    "emailpro": {
+      "type": ["string", "null"],
+      "description": "secondary email address for patron's primary address"
+    },
+    "phonepro": {
+      "type": ["string", "null"],
+      "description": "secondary phone number for patron's primary address"
+    },
+    "B_streetnumber": {
+      "type": ["string", "null"],
+      "description": "street number of patron's alternate address"
+    },
+    "B_streettype": {
+      "type": ["string", "null"],
+      "description": "street type of patron's alternate address"
+    },
+    "B_address": {
+      "type": ["string", "null"],
+      "description": "first address line of patron's alternate address"
+    },
+    "B_address2": {
+      "type": ["string", "null"],
+      "description": "second address line of patron's alternate address"
+    },
+    "B_city": {
+      "type": ["string", "null"],
+      "description": "city or town of patron's alternate address"
+    },
+    "B_state": {
+      "type": ["string", "null"],
+      "description": "state or province of patron's alternate address"
+    },
+    "B_zipcode": {
+      "type": ["string", "null"],
+      "description": "zip or postal code of patron's alternate address"
+    },
+    "B_country": {
+      "type": ["string", "null"],
+      "description": "country of patron's alternate address"
+    },
+    "B_email": {
+      "type": ["string", "null"],
+      "description": "email address for patron's alternate address"
+    },
+    "B_phone": {
+      "type": ["string", "null"],
+      "description": "phone number for patron's alternate address"
+    },
+    "dateofbirth": {
+      "type": ["string", "null"],
+      "description": "patron's date of birth",
+      "format": "date"
+    },
+    "branchcode": {
+      "type": "string",
+      "description": "code of patron's home branch"
+    },
+    "categorycode": {
+      "type": "string",
+      "description": "code of patron's category"
+    },
+    "dateenrolled": {
+      "type": ["string", "null"],
+      "description": "date the patron was added to Koha",
+      "format": "date"
+    },
+    "dateexpiry": {
+      "type": ["string", "null"],
+      "description": "date the patron's card is set to expire",
+      "format": "date"
+    },
+    "gonenoaddress": {
+      "type": ["boolean", "null"],
+      "description": "set to 1 if library marked this patron as having an unconfirmed address"
+    },
+    "lost": {
+      "type": ["boolean", "null"],
+      "description": "set to 1 if library marked this patron as having lost his card"
+    },
+    "debarred": {
+      "type": ["string", "null"],
+      "description": "until this date the patron can only check-in",
+      "format": "date"
+    },
+    "debarredcomment": {
+      "type": ["string", "null"],
+      "description": "comment on the stop of the patron"
+    },
+    "contactname": {
+      "type": ["string", "null"],
+      "description": "used for children and professionals to include surname or last name of guarantor or organization name"
+    },
+    "contactfirstname": {
+      "type": ["string", "null"],
+      "description": "used for children to include first name of guarantor"
+    },
+    "contacttitle": {
+      "type": ["string", "null"],
+      "description": "used for children to include title of guarantor"
+    },
+    "guarantorid": {
+      "type": ["integer", "null"],
+      "description": "borrowernumber used for children or professionals to link them to guarantor or organizations"
+    },
+    "borrowernotes": {
+      "type": ["string", "null"],
+      "description": "a note on the patron's account"
+    },
+    "relationship": {
+      "type": ["string", "null"],
+      "description": "used for children to include the relationship to their guarantor"
+    },
+    "sex": {
+      "type": ["string", "null"],
+      "description": "patron's gender"
+    },
+    "password": {
+      "type": ["string", "null"],
+      "description": "patron's encrypted password"
+    },
+    "flags": {
+      "type": ["integer", "null"],
+      "description": "a number associated with the patron's permissions"
+    },
+    "userid": {
+      "type": ["string", "null"],
+      "description": "patron's login"
+    },
+    "opacnote": {
+      "type": ["string", "null"],
+      "description": "a note on the patron's account visible in OPAC and staff client"
+    },
+    "contactnote": {
+      "type": ["string", "null"],
+      "description": "a note related to patron's alternate address"
+    },
+    "sort1": {
+      "type": ["string", "null"],
+      "description": "a field that can be used for any information unique to the library"
+    },
+    "sort2": {
+      "type": ["string", "null"],
+      "description": "a field that can be used for any information unique to the library"
+    },
+    "altcontactfirstname": {
+      "type": ["string", "null"],
+      "description": "first name of alternate contact for the patron"
+    },
+    "altcontactsurname": {
+      "type": ["string", "null"],
+      "description": "surname or last name of the alternate contact for the patron"
+    },
+    "altcontactaddress1": {
+      "type": ["string", "null"],
+      "description": "the first address line for the alternate contact for the patron"
+    },
+    "altcontactaddress2": {
+      "type": ["string", "null"],
+      "description": "the second address line for the alternate contact for the patron"
+    },
+    "altcontactaddress3": {
+      "type": ["string", "null"],
+      "description": "the city for the alternate contact for the patron"
+    },
+    "altcontactstate": {
+      "type": ["string", "null"],
+      "description": "the state for the alternate contact for the patron"
+    },
+    "altcontactzipcode": {
+      "type": ["string", "null"],
+      "description": "the zipcode for the alternate contact for the patron"
+    },
+    "altcontactcountry": {
+      "type": ["string", "null"],
+      "description": "the country for the alternate contact for the patron"
+    },
+    "altcontactphone": {
+      "type": ["string", "null"],
+      "description": "the phone number for the alternate contact for the patron"
+    },
+    "smsalertnumber": {
+      "type": ["string", "null"],
+      "description": "the mobile phone number where the patron would like to receive notices (if SMS turned on)"
+    },
+    "sms_provider_id": {
+      "type": ["integer", "null"],
+      "description": "the provider of the mobile phone number defined in smsalertnumber"
+    },
+    "privacy": {
+      "type": "integer",
+      "description": "patron's privacy settings related to their reading history"
+    },
+    "privacy_guarantor_checkouts": {
+      "type": "integer",
+      "description": "controls if relatives can see this patron's checkouts"
+    },
+    "checkprevcheckout": {
+      "type": "string",
+      "description": "produce a warning for this patron if this item has previously been checked out to this patron if 'yes', not if 'no', defer to category setting if 'inherit'"
+    },
+    "updated_on": {
+      "type": ["string", "null"],
+      "description": "time of last change could be useful for synchronization with external systems (among others)",
+      "format": "date-time"
+    },
+    "lastseen": {
+      "type": ["string", "null"],
+      "description": "last time a patron has been seen (connected at the OPAC or staff interface)",
+      "format": "date-time"
+    }
+  }
+}

--- a/t/spec/koha-swagger/definitions/patronstatus.json
+++ b/t/spec/koha-swagger/definitions/patronstatus.json
@@ -1,0 +1,79 @@
+{
+  "type": "object",
+  "allOf": [
+    { "$ref": "patron.json" },
+    {
+    "type": "object",
+    "properties": {
+      "blocks": {
+        "type": "object",
+        "properties": {
+        "Patron::CardExpired": {
+          "description": "Patron's card has been expired.",
+          "type": "object",
+          "properties": {
+            "expiration_date": {
+              "type": ["string", "null"]
+            }
+          }
+        },
+        "Patron::CardLost": {
+          "description": "Patron's card has been marked as lost.",
+          "type": "object",
+          "properties": {}
+        },
+        "Patron::Debarred": {
+          "description": "Patron is debarred.",
+          "type": "object",
+          "properties": {
+            "expiration_date": {
+              "type": ["string", "null"]
+            },
+            "comment": {
+              "type": ["string", "null"]
+            }
+          }
+        },
+        "Patron::DebarredOverdue": {
+          "description": "Patron has overdues and is debarred.",
+          "type": "object",
+          "properties": {
+            "number_of_overdues": {
+              "type": ["integer", "null"]
+            }
+          }
+        },
+        "Patron::Debt": {
+          "description": "Patron's debts exceed maximum allowed amount.",
+          "type": "object",
+          "properties": {
+            "max_outstanding":{
+              "type": ["number", "null"]
+            },
+            "current_outstanding": {
+              "type": ["number", "null"]
+            }
+          }
+        },
+        "Patron::DebtGuarantees": {
+          "description": "Patron's guarantees' debts exceed maximum allowed amount.",
+          "type": "object",
+          "properties": {
+            "max_outstanding":{
+              "type": ["number", "null"]
+            },
+            "current_outstanding": {
+              "type": ["number", "null"]
+            }
+          }
+        },
+        "Patron::GoneNoAddress": {
+          "type": "object",
+          "properties": {}
+        }
+      }
+      }
+    }
+    }
+  ]
+}

--- a/t/spec/koha-swagger/definitions/renewability.json
+++ b/t/spec/koha-swagger/definitions/renewability.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "renewable": {
+      "type": "boolean",
+      "description": "Renewability status; true = renewable, false = not renewable"
+    },
+    "error": {
+      "type": ["string", "null"],
+      "description": "Description on false renewability."
+    }
+  }
+}

--- a/t/spec/koha-swagger/definitions/session.json
+++ b/t/spec/koha-swagger/definitions/session.json
@@ -1,0 +1,32 @@
+{
+  "type": "object",
+  "properties": {
+    "borrowernumber": {
+      "type": "integer",
+      "description": "internally assigned user identifier"
+    },
+    "email": {
+      "type": ["string", "null"],
+      "description": "primary email address for patron's primary address"
+    },
+    "surname": {
+      "type": "string",
+      "description": "patron's last name"
+    },
+    "firstname": {
+      "type": ["string", "null"],
+      "description": "patron's first name"
+    },
+    "sessionid": {
+      "description": "Koha Session identifier",
+      "type": "string"
+    },
+    "permissions": {
+      "description": "patron's permissions",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/t/spec/koha-swagger/definitions/sessionid.json
+++ b/t/spec/koha-swagger/definitions/sessionid.json
@@ -1,0 +1,10 @@
+{
+  "type": "object",
+  "properties": {
+    "sessionid": {
+      "description": "The Koha sessionid",
+      "type": "string"
+    }
+  },
+  "required": ["sessionid"]
+}

--- a/t/spec/koha-swagger/parameters.json
+++ b/t/spec/koha-swagger/parameters.json
@@ -1,0 +1,59 @@
+{
+  "accountlinesIdPathParam": {
+    "$ref": "parameters/accountline.json#/accountlinesIdPathParam"
+  },
+  "biblionumbersQueryParam": {
+    "$ref": "parameters/biblio.json#/biblionumbersQueryParam"
+  },
+  "borrowernumberPathParam": {
+    "$ref": "parameters/patron.json#/borrowernumberPathParam"
+  },
+  "borrowernumberQueryParam": {
+    "$ref": "parameters/patron.json#/borrowernumberQueryParam"
+  },
+  "branchcodePathParam": {
+    "$ref": "parameters/library.json#/branchcodePathParam"
+  },
+  "branchcodeQueryParam": {
+    "$ref": "parameters/library.json#/branchcodeQueryParam"
+  },
+  "cardnumberPostParam": {
+    "$ref": "parameters/auth.json#/cardnumberPostParam"
+  },
+  "cardnumberQueryParam": {
+    "$ref": "parameters/patron.json#/cardnumberQueryParam"
+  },
+  "cityidPathParam": {
+    "$ref": "parameters/city.json#/cityidPathParam"
+  },
+  "holdIdPathParam": {
+    "$ref": "parameters/hold.json#/holdIdPathParam"
+  },
+  "checkoutIdPathParam": {
+    "$ref": "parameters/checkout.json#/checkoutIdPathParam"
+  },
+  "itemnumberPathParam": {
+    "$ref": "parameters/item.json#/itemnumberPathParam"
+  },
+  "itemnumbersQueryParam": {
+    "$ref": "parameters/item.json#/itemnumbersQueryParam"
+  },
+  "passwordPostParam": {
+   "$ref": "parameters/auth.json#/passwordPostParam"
+  },
+  "useridPostParam": {
+   "$ref": "parameters/auth.json#/useridPostParam"
+  },
+  "useridQueryParam": {
+   "$ref": "parameters/patron.json#/useridQueryParam"
+  },
+  "sessionidBodyParam": {
+   "$ref": "parameters/auth.json#/sessionidBodyParam"
+  },
+  "surnameQueryParam": {
+    "$ref": "parameters/patron.json#/surnameQueryParam"
+  },
+  "biblionumberPathParam": {
+    "$ref": "parameters/biblio.json#/biblionumberPathParam"
+  }
+}

--- a/t/spec/koha-swagger/parameters/accountline.json
+++ b/t/spec/koha-swagger/parameters/accountline.json
@@ -1,0 +1,9 @@
+{
+  "accountlinesIdPathParam": {
+    "name": "accountlines_id",
+    "in": "path",
+    "description": "Internal accountline identifier",
+    "required": true,
+    "type": "integer"
+  }
+}

--- a/t/spec/koha-swagger/parameters/auth.json
+++ b/t/spec/koha-swagger/parameters/auth.json
@@ -1,0 +1,31 @@
+{
+  "cardnumberPostParam": {
+    "name": "cardnumber",
+    "in": "formData",
+    "description": "Borrower's card's barcode/identifier",
+    "required": false,
+    "type": "string"
+  },
+  "passwordPostParam": {
+    "name": "password",
+    "in": "formData",
+    "required": true,
+    "type": "string"
+  },
+  "useridPostParam": {
+    "name": "userid",
+    "in": "formData",
+    "description": "The userid of the Borrower, unique value",
+    "required": false,
+    "type": "string"
+  },
+  "sessionidBodyParam": {
+    "name": "session",
+    "description": "The CGISESSID Cookie used to authenticate a session",
+    "in": "body",
+    "required": false,
+    "schema" : {
+      "$ref": "../definitions/sessionid.json"
+    }
+  }
+}

--- a/t/spec/koha-swagger/parameters/biblio.json
+++ b/t/spec/koha-swagger/parameters/biblio.json
@@ -1,0 +1,19 @@
+{
+  "biblionumberPathParam": {
+     "name": "biblionumber",
+     "in": "path",
+     "description": "Internal biblio identifier",
+     "required": true,
+     "type": "integer"
+  },
+  "biblionumbersQueryParam": {
+    "name": "biblionumber",
+    "in": "query",
+    "description": "Internal biblios identifier",
+    "type": "array",
+    "items": {
+      "type": "integer"
+    },
+    "collectionFormat": "ssv"
+  }
+}

--- a/t/spec/koha-swagger/parameters/checkout.json
+++ b/t/spec/koha-swagger/parameters/checkout.json
@@ -1,0 +1,9 @@
+{
+  "checkoutIdPathParam": {
+    "name": "checkout_id",
+    "in": "path",
+    "description": "Internal checkout identifier",
+    "required": true,
+    "type": "integer"
+  }
+}

--- a/t/spec/koha-swagger/parameters/city.json
+++ b/t/spec/koha-swagger/parameters/city.json
@@ -1,0 +1,9 @@
+{
+    "cityidPathParam": {
+      "name": "cityid",
+      "in": "path",
+      "description": "City id",
+      "required": true,
+      "type": "integer"
+    }
+}

--- a/t/spec/koha-swagger/parameters/hold.json
+++ b/t/spec/koha-swagger/parameters/hold.json
@@ -1,0 +1,9 @@
+{
+  "holdIdPathParam": {
+    "name": "reserve_id",
+    "in": "path",
+    "description": "Internal hold identifier",
+    "required": true,
+    "type": "integer"
+  }
+}

--- a/t/spec/koha-swagger/parameters/item.json
+++ b/t/spec/koha-swagger/parameters/item.json
@@ -1,0 +1,19 @@
+{
+  "itemnumberPathParam": {
+    "name": "itemnumber",
+    "in": "path",
+    "description": "Internal item identifier",
+    "required": true,
+    "type": "integer"
+  },
+  "itemnumbersQueryParam": {
+    "name": "itemnumber",
+    "in": "query",
+    "description": "Internal items identifier",
+    "type": "array",
+    "items": {
+      "type": "integer"
+    },
+    "collectionFormat": "ssv"
+  }
+}

--- a/t/spec/koha-swagger/parameters/library.json
+++ b/t/spec/koha-swagger/parameters/library.json
@@ -1,0 +1,15 @@
+{
+  "branchcodePathParam": {
+    "name": "branchcode",
+    "in": "path",
+    "description": "Branch identifier code",
+    "required": true,
+    "type": "string"
+  },
+  "branchcodeQueryParam": {
+    "name": "branchcode",
+    "in": "query",
+    "description": "Branch identifier code",
+    "type": "string"
+  }
+}

--- a/t/spec/koha-swagger/parameters/patron.json
+++ b/t/spec/koha-swagger/parameters/patron.json
@@ -1,0 +1,33 @@
+{
+  "borrowernumberPathParam": {
+    "name": "borrowernumber",
+    "in": "path",
+    "description": "Internal patron identifier",
+    "required": true,
+    "type": "integer"
+  },
+  "borrowernumberQueryParam": {
+    "name": "borrowernumber",
+    "in": "query",
+    "description": "Internal borrower identifier",
+    "type": "integer"
+  },
+  "cardnumberQueryParam": {
+    "name": "cardnumber",
+    "in": "query",
+    "description": "Patron cardnumber",
+    "type": "string"
+  },
+  "useridQueryParam": {
+    "name": "userid",
+    "in": "query",
+    "description": "Patron userid",
+    "type": "string"
+  },
+  "surnameQueryParam": {
+    "name": "surname",
+    "in": "query",
+    "description": "Patron surname query parameter",
+    "type": "string"
+  }
+}

--- a/t/spec/koha-swagger/paths.json
+++ b/t/spec/koha-swagger/paths.json
@@ -1,0 +1,92 @@
+{
+  "/accountlines": {
+    "$ref": "paths/accountlines.json#/~1accountlines"
+  },
+  "/accountlines/{accountlines_id}": {
+    "$ref": "paths/accountlines.json#/~1accountlines~1{accountlines_id}"
+  },
+  "/accountlines/{accountlines_id}/payment": {
+    "$ref": "paths/accountlines.json#/~1accountlines~1{accountlines_id}~1payment"
+  },
+  "/auth/session": {
+    "$ref": "paths/auth.json#/~1auth~1session"
+  },
+  "/availability/biblio/hold": {
+    "$ref": "paths/availability.json#/~1availability~1biblio~1hold"
+  },
+  "/availability/biblio/search": {
+    "$ref": "paths/availability.json#/~1availability~1biblio~1search"
+  },
+  "/availability/item/checkout": {
+    "$ref": "paths/availability.json#/~1availability~1item~1checkout"
+  },
+  "/availability/item/hold": {
+    "$ref": "paths/availability.json#/~1availability~1item~1hold"
+  },
+  "/availability/item/search": {
+    "$ref": "paths/availability.json#/~1availability~1item~1search"
+  },
+  "/biblios": {
+    "$ref": "paths/biblios.json#/~1biblios"
+  },
+  "/biblios/{biblionumber}": {
+    "$ref": "paths/biblios.json#/~1biblios~1{biblionumber}"
+  },
+  "/biblios/{biblionumber}/items": {
+    "$ref": "paths/biblios.json#/~1biblios~1{biblionumber}~1items"
+  },
+  "/biblios/{biblionumber}/expanded": {
+    "$ref": "paths/biblios.json#/~1biblios~1{biblionumber}~1expanded"
+  },
+  "/cities": {
+    "$ref": "paths/cities.json#/~1cities"
+  },
+  "/cities/{cityid}": {
+    "$ref": "paths/cities.json#/~1cities~1{cityid}"
+  },
+  "/holds": {
+    "$ref": "paths/holds.json#/~1holds"
+  },
+  "/holds/{reserve_id}": {
+    "$ref": "paths/holds.json#/~1holds~1{reserve_id}"
+  },
+  "/checkouts": {
+    "$ref": "paths/checkouts.json#/~1checkouts"
+  },
+  "/checkouts/{checkout_id}": {
+    "$ref": "paths/checkouts.json#/~1checkouts~1{checkout_id}"
+  },
+  "/checkouts/{checkout_id}/renewability": {
+    "$ref": "paths/checkouts.json#/~1checkouts~1{checkout_id}~1renewability"
+  },
+  "/checkouts/history": {
+    "$ref": "paths/checkouts.json#/~1checkouts~1history"
+  },
+  "/checkouts/history/{checkout_id}": {
+    "$ref": "paths/checkouts.json#/~1checkouts~1history~1{checkout_id}"
+  },
+  "/items/{itemnumber}": {
+    "$ref": "paths/items.json#/~1items~1{itemnumber}"
+  },
+  "/libraries": {
+    "$ref": "paths/libraries.json#/~1libraries"
+  },
+  "/libraries/{branchcode}": {
+    "$ref": "paths/libraries.json#/~1libraries~1{branchcode}"
+  },
+  "/patrons": {
+    "$ref": "paths/patrons.json#/~1patrons"
+  },
+  "/patrons/{borrowernumber}": {
+    "$ref": "paths/patrons.json#/~1patrons~1{borrowernumber}"
+  },
+  "/patrons/{borrowernumber}/password": {
+    "$ref": "paths/patrons.json#/~1patrons~1{borrowernumber}~1password"
+  },
+  "/patrons/{borrowernumber}/payment": {
+    "$ref": "paths/patrons.json#/~1patrons~1{borrowernumber}~1payment"
+  },
+  "/patrons/{borrowernumber}/status": {
+    "$ref": "paths/patrons.json#/~1patrons~1{borrowernumber}~1status"
+  }
+}

--- a/t/spec/koha-swagger/paths/accountlines.json
+++ b/t/spec/koha-swagger/paths/accountlines.json
@@ -1,0 +1,226 @@
+{
+  "/accountlines": {
+    "get": {
+      "x-mojo-to": "Accountline#list",
+      "operationId": "listAccountlines",
+      "tags": ["accountlines"],
+      "parameters": [
+        {
+          "$ref": "../parameters.json#/borrowernumberQueryParam"
+        }
+      ],
+      "produces": [
+        "application/json"
+      ],
+      "responses": {
+        "200": {
+          "description": "A list of accountlines",
+          "schema": {
+            "type": "array",
+            "items": {
+              "$ref": "../definitions.json#/accountline"
+            }
+          }
+        },
+        "400": {
+          "description": "Bad parameter",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "401": {
+          "description": "Authentication required",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "403": {
+          "description": "Access forbidden",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "500": {
+          "description": "Internal error",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "503": {
+          "description": "Under maintenance",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        }
+      },
+      "x-koha-authorization": {
+        "allow-owner": true,
+        "allow-guarantor": true,
+        "permissions": {
+            "updatecharges": "1"
+        }
+      }
+    }
+  },
+  "/accountlines/{accountlines_id}": {
+    "put": {
+      "x-mojo-to": "Accountline#edit",
+      "operationId": "editAccountlines",
+      "tags": ["accountlines"],
+      "produces": [
+        "application/json"
+      ],
+      "parameters": [
+        { "$ref": "../parameters.json#/accountlinesIdPathParam" },
+        {
+          "name": "body",
+          "in": "body",
+          "description": "A JSON object containing fields to modify",
+          "required": true,
+          "schema": {
+            "type": "object",
+            "properties": {
+              "amount": {
+                "description": "Amount",
+                "type": ["number", "null"]
+              },
+              "amountoutstanding": {
+                "description": "Amount outstanding",
+                "type": ["number", "null"]
+              },
+              "note": {
+                "description": "Accountline note",
+                "type": ["string", "null"]
+              }
+            }
+          }
+        }
+      ],
+      "consumes": ["application/json"],
+      "produces": ["application/json"],
+      "responses": {
+        "200": {
+          "description": "Updated accountline",
+          "schema": { "$ref": "../definitions.json#/accountline" }
+        },
+        "400": {
+          "description": "Missing or wrong parameters",
+          "schema": { "$ref": "../definitions.json#/error" }
+        },
+        "401": {
+          "description": "Authentication required",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "403": {
+          "description": "Access forbidden",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "404": {
+          "description": "Accountline not found",
+          "schema": { "$ref": "../definitions.json#/error" }
+        },
+        "500": {
+          "description": "Internal error",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "503": {
+          "description": "Under maintenance",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        }
+      },
+      "x-koha-authorization": {
+        "permissions": {
+          "updatecharges": "1"
+        }
+      }
+    }
+  },
+  "/accountlines/{accountlines_id}/payment": {
+    "post": {
+      "x-mojo-to": "Accountline#pay",
+      "operationId": "payAccountlines",
+      "tags": ["accountlines"],
+      "produces": [
+        "application/json"
+      ],
+      "parameters": [
+        { "$ref": "../parameters.json#/accountlinesIdPathParam" },
+        {
+          "name": "body",
+          "in": "body",
+          "required": true,
+          "description": "A JSON object containing fields to modify",
+          "schema": {
+            "type": "object",
+            "properties": {
+              "amount": {
+                "description": "Amount to pay. If not given, the whole accountline will be paid.",
+                "type": "number",
+                "exclusiveMinimum": true,
+                "minimum": 0
+              },
+              "note": {
+                "description": "Payment note",
+                "type": "string"
+              }
+            },
+            "required": ["amount"]
+          }
+        }
+      ],
+      "consumes": ["application/json"],
+      "produces": ["application/json"],
+      "responses": {
+        "200": {
+          "description": "Paid accountline",
+          "schema": { "$ref": "../definitions.json#/accountline" }
+        },
+        "400": {
+          "description": "Missing or wrong parameters",
+          "schema": { "$ref": "../definitions.json#/error" }
+        },
+        "401": {
+          "description": "Authentication required",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "403": {
+          "description": "Access forbidden",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "404": {
+          "description": "Accountline not found",
+          "schema": { "$ref": "../definitions.json#/error" }
+        },
+        "500": {
+          "description": "Internal error",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "503": {
+          "description": "Under maintenance",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        }
+      },
+      "x-koha-authorization": {
+        "permissions": {
+          "updatecharges": "1"
+        }
+      }
+    }
+  }
+}

--- a/t/spec/koha-swagger/paths/auth.json
+++ b/t/spec/koha-swagger/paths/auth.json
@@ -1,0 +1,90 @@
+{
+  "/auth/session": {
+    "post": {
+      "x-mojo-to": "Auth#login",
+      "operationId": "loginAuth",
+      "tags": ["auth"],
+      "summary": "Login to Koha and get a session cookie",
+      "description": "Makes a 'normal' username + password login to Koha, and returns the sessionid you need put to the CGISESSID-cookie. Koha uses this cookie to track a session.\nBe aware that the authenticated session most probably is IP-locked so authenticating from one IP and passing the session to another wont work.",
+      "parameters": [
+        { "$ref": "../parameters.json#/cardnumberPostParam" },
+        { "$ref": "../parameters.json#/useridPostParam" },
+        { "$ref": "../parameters.json#/passwordPostParam" }
+      ],
+      "produces": [
+        "application/json"
+      ],
+      "responses": {
+        "201": {
+          "description": "A borrower with SSO-relevant fields",
+          "schema": {
+            "$ref": "../definitions.json#/session"
+          }
+        },
+        "400": {
+          "description": "Bad parameters",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "401": {
+          "description": "Bad username/cardnumber and/or password",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "500": {
+          "description": "Internal error",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "503": {
+          "description": "Under maintenance",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        }
+      }
+    },
+    "delete": {
+      "x-mojo-to": "Auth#logout",
+      "operationId": "logoutAuth",
+      "tags": ["auth"],
+      "summary": "Logout from Koha.",
+      "description": "Logouts user from Koha by marking session as expired. sessionid is optional, if not given, logs out currently logged in user",
+      "parameters": [
+        { "$ref": "../parameters.json#/sessionidBodyParam" }
+      ],
+      "produces": [
+        "application/json"
+      ],
+      "responses": {
+        "200": {
+          "description": "Successfully logged out",
+          "schema": {
+            "type": "object"
+          }
+        },
+        "401": {
+          "description": "Bad session id",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "500": {
+          "description": "Internal error",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "503": {
+          "description": "Under maintenance",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        }
+      }
+    }
+  }
+}

--- a/t/spec/koha-swagger/paths/availability.json
+++ b/t/spec/koha-swagger/paths/availability.json
@@ -1,0 +1,245 @@
+{
+  "/availability/biblio/hold": {
+    "get": {
+      "x-mojo-to": "BiblioAvailability#hold",
+      "operationId": "holdBiblioAvailability",
+      "tags": ["items", "availability"],
+      "parameters": [
+        { "$ref": "../parameters.json#/biblionumbersQueryParam" },
+        { "$ref": "../parameters.json#/borrowernumberQueryParam" },
+        { "$ref": "../parameters.json#/branchcodeQueryParam"},
+        {
+          "name": "limit_items",
+          "in": "query",
+          "description": "Check only first n available items.",
+          "required": false,
+          "type": "integer"
+        }
+      ],
+      "consumes": ["application/json"],
+      "produces": ["application/json"],
+      "responses": {
+        "200": {
+          "description": "Hold availability information for items of biblio.",
+          "schema": {
+            "type": "array",
+            "items": { "$ref": "../definitions.json#/availability~1biblio" }
+          }
+        },
+        "400": {
+          "description": "Missing or invalid parameters",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "401": {
+          "description": "Authentication required",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "500": {
+          "description": "Internal server error",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "503": {
+          "description": "Under maintenance",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        }
+      }
+    }
+  },
+  "/availability/biblio/search": {
+    "get": {
+      "x-mojo-to": "BiblioAvailability#search",
+      "operationId": "searchBiblioAvailability",
+      "tags": ["items", "availability"],
+      "parameters": [
+        { "$ref": "../parameters.json#/biblionumbersQueryParam" }
+      ],
+      "consumes": ["application/json"],
+      "produces": ["application/json"],
+      "responses": {
+        "200": {
+          "description": "Availability information in search context for items of biblio.",
+          "schema": {
+            "type": "array",
+            "items": { "$ref": "../definitions.json#/availability~1biblio" }
+          }
+        },
+        "400": {
+          "description": "Missing or invalid parameters",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "500": {
+          "description": "Internal server error",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "503": {
+          "description": "Under maintenance",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        }
+      }
+    }
+  },
+  "/availability/item/checkout": {
+    "get": {
+      "x-mojo-to": "ItemAvailability#checkout",
+      "operationId": "checkoutItemAvailability",
+      "tags": ["items", "availability"],
+      "parameters": [
+        { "$ref": "../parameters.json#/itemnumbersQueryParam" },
+        { "$ref": "../parameters.json#/borrowernumberQueryParam" }
+      ],
+      "consumes": ["application/json"],
+      "produces": ["application/json"],
+      "responses": {
+        "200": {
+          "description": "Checkout availability information for specific item(s).",
+          "schema": {
+            "type": "array",
+            "items": { "$ref": "../definitions.json#/availability~1item" }
+          }
+        },
+        "400": {
+          "description": "Missing or invalid parameters",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "401": {
+          "description": "Authentication required",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "500": {
+          "description": "Internal server error",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "503": {
+          "description": "Under maintenance",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        }
+      }
+    }
+  },
+  "/availability/item/hold": {
+    "get": {
+      "x-mojo-to": "ItemAvailability#hold",
+      "operationId": "holdItemAvailability",
+      "tags": ["items", "availability"],
+      "parameters": [
+        { "$ref": "../parameters.json#/itemnumbersQueryParam" },
+        { "$ref": "../parameters.json#/borrowernumberQueryParam" },
+        { "$ref": "../parameters.json#/branchcodeQueryParam"}
+      ],
+      "consumes": ["application/json"],
+      "produces": ["application/json"],
+      "responses": {
+        "200": {
+          "description": "Hold availability information for specific item(s).",
+          "schema": {
+            "type": "array",
+            "items": { "$ref": "../definitions.json#/availability~1item" }
+          }
+        },
+        "400": {
+          "description": "Missing or invalid parameters",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "401": {
+          "description": "Authentication required",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "500": {
+          "description": "Internal server error",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "503": {
+          "description": "Under maintenance",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        }
+      }
+    }
+  },
+  "/availability/item/search": {
+    "get": {
+      "x-mojo-to": "ItemAvailability#search",
+      "operationId": "searchItemAvailability",
+      "tags": ["items", "availability"],
+      "parameters": [
+        { "$ref": "../parameters.json#/itemnumbersQueryParam" }
+      ],
+      "consumes": ["application/json"],
+      "produces": ["application/json"],
+      "responses": {
+        "200": {
+          "description": "Availability information in search context for specific item(s).",
+          "schema": {
+            "type": "array",
+            "items": { "$ref": "../definitions.json#/availability~1item" }
+          }
+        },
+        "400": {
+          "description": "Missing or invalid parameters",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "500": {
+          "description": "Internal server error",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "503": {
+          "description": "Under maintenance",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        }
+      }
+    }
+  }
+}

--- a/t/spec/koha-swagger/paths/biblios.json
+++ b/t/spec/koha-swagger/paths/biblios.json
@@ -1,0 +1,267 @@
+{
+  "/biblios/{biblionumber}": {
+    "get": {
+      "x-mojo-to": "Biblio#get",
+      "operationId": "getBiblio",
+      "tags": ["biblios"],
+      "parameters": [
+        { "$ref": "../parameters.json#/biblionumberPathParam" }
+      ],
+      "produces": [
+        "application/json"
+      ],
+      "responses": {
+        "200": {
+          "description": "A biblio record",
+          "schema": { "$ref": "../definitions.json#/biblio" }
+
+        },
+        "404": {
+          "description": "Biblio not found",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "500": {
+          "description": "Internal error",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "503": {
+          "description": "Under maintenance",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        }
+      }
+    },
+    "put": {
+      "x-mojo-to": "Biblio#update",
+      "operationId": "updateBiblio",
+      "tags": ["biblios"],
+      "parameters": [
+        { "$ref": "../parameters.json#/biblionumberPathParam" }
+      ],
+      "produces": [
+        "application/json"
+      ],
+      "responses": {
+        "200": {
+          "description": "An updated biblio record"
+        },
+        "400": {
+          "description": "Biblio update failed",
+          "schema": { "$ref": "../definitions.json#/error" }
+        },
+        "401": {
+          "description": "Authentication required",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "403": {
+          "description": "Access forbidden",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "404": {
+          "description": "Biblio not found",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "500": {
+          "description": "Internal error",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "503": {
+          "description": "Under maintenance",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        }
+      },
+      "x-koha-authorization": {
+        "permissions": {
+          "editcatalogue": "1"
+        }
+      }
+    },
+    "delete": {
+      "x-mojo-to": "Biblio#delete",
+      "operationId": "deleteBiblio",
+      "tags": ["biblios"],
+      "parameters": [
+        { "$ref": "../parameters.json#/biblionumberPathParam" }
+      ],
+      "produces": ["application/json"],
+      "responses": {
+        "200": {
+          "description": "Biblio record deleted successfully",
+          "schema": {
+            "type": "object"
+          }
+        },
+        "400": {
+          "description": "Biblio deletion failed",
+          "schema": { "$ref": "../definitions.json#/error" }
+        },
+        "401": {
+          "description": "Authentication required",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "403": {
+          "description": "Access forbidden",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "404": {
+          "description": "Biblio not found",
+          "schema": { "$ref": "../definitions.json#/error" }
+        },
+        "500": {
+          "description": "Internal error",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "503": {
+          "description": "Under maintenance",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        }
+      },
+      "x-koha-authorization": {
+        "permissions": {
+          "editcatalogue": "1"
+        }
+      }
+    }
+  },
+  "/biblios/{biblionumber}/items": {
+    "get": {
+      "x-mojo-to": "Biblio#getitems",
+      "operationId": "getitemsByBiblio",
+      "tags": ["biblios", "items"],
+      "parameters": [
+        { "$ref": "../parameters.json#/biblionumberPathParam" }
+      ],
+      "produces": [
+        "application/json"
+      ],
+      "responses": {
+        "200": {
+          "description": "A biblio record with items"
+        },
+        "404": {
+          "description": "Biblio not found",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "500": {
+          "description": "Internal error",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "503": {
+          "description": "Under maintenance",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        }
+      }
+    }
+  },
+  "/biblios/{biblionumber}/expanded": {
+    "get": {
+      "x-mojo-to": "Biblio#getexpanded",
+      "operationId": "getexpandedByBiblio",
+      "tags": ["biblios", "items", "item status"],
+      "parameters": [
+        { "$ref": "../parameters.json#/biblionumberPathParam" }
+      ],
+      "produces": [
+        "application/json"
+      ],
+      "responses": {
+        "200": {
+          "description": "A biblio record with items and item statuses"
+        },
+        "404": {
+          "description": "Biblio not found",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "500": {
+          "description": "Internal error",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "503": {
+          "description": "Under maintenance",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        }
+      }
+    }
+  },
+  "/biblios": {
+    "post": {
+      "x-mojo-to": "Biblio#add",
+      "operationId": "addBiblio",
+      "tags": ["biblios"],
+      "produces": ["application/json"],
+      "responses": {
+        "201": {
+          "description": "A new biblio record"
+        },
+        "400": {
+          "description": "Unable to create biblio record",
+          "schema": { "$ref": "../definitions.json#/error" }
+        },
+        "401": {
+          "description": "Authentication required",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "403": {
+          "description": "Access forbidden",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "500": {
+          "description": "Internal error",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "503": {
+          "description": "Under maintenance",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        }
+      }
+    },
+    "x-koha-authorization": {
+      "permissions": {
+        "editcatalogue": "1"
+      }
+    }
+  }
+}

--- a/t/spec/koha-swagger/paths/checkouts.json
+++ b/t/spec/koha-swagger/paths/checkouts.json
@@ -1,0 +1,307 @@
+{
+  "/checkouts": {
+    "get": {
+      "x-mojo-to": "Checkout#list",
+      "operationId": "listCheckouts",
+      "tags": ["patrons", "checkouts"],
+      "parameters": [{
+        "$ref": "../parameters.json#/borrowernumberQueryParam"
+      }],
+      "produces": [
+        "application/json"
+      ],
+      "responses": {
+        "200": {
+          "description": "A list of checkouts",
+          "schema": {
+            "$ref": "../definitions.json#/checkouts"
+          }
+        },
+        "401": {
+          "description": "Authentication required",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "403": {
+          "description": "Access forbidden",
+          "schema": { "$ref": "../definitions.json#/error" }
+        },
+        "404": {
+          "description": "Patron not found",
+          "schema": { "$ref": "../definitions.json#/error" }
+        },
+        "500": {
+          "description": "Internal error",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "503": {
+          "description": "Under maintenance",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        }
+      },
+      "x-koha-authorization": {
+        "allow-owner": true,
+        "allow-guarantor": true,
+        "permissions": {
+          "circulate": "circulate_remaining_permissions"
+        }
+      }
+    }
+  },
+  "/checkouts/{checkout_id}": {
+    "get": {
+      "x-mojo-to": "Checkout#get",
+      "operationId": "getCheckout",
+      "tags": ["patrons", "checkouts"],
+      "parameters": [{
+        "$ref": "../parameters.json#/checkoutIdPathParam"
+      }],
+      "produces": ["application/json"],
+      "responses": {
+        "200": {
+          "description": "Updated borrower's checkout",
+          "schema": { "$ref": "../definitions.json#/checkout" }
+        },
+        "401": {
+          "description": "Authentication required",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "403": {
+          "description": "Access forbidden",
+          "schema": { "$ref": "../definitions.json#/error" }
+        },
+        "404": {
+          "description": "Checkout not found",
+          "schema": { "$ref": "../definitions.json#/error" }
+        },
+        "500": {
+          "description": "Internal error",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "503": {
+          "description": "Under maintenance",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        }
+      },
+      "x-koha-authorization": {
+        "allow-owner": true,
+        "allow-guarantor": true,
+        "permissions": {
+          "circulate": "circulate_remaining_permissions"
+        }
+      }
+    },
+    "put": {
+      "x-mojo-to": "Checkout#renew",
+      "operationId": "renewCheckout",
+      "tags": ["patrons", "checkouts"],
+      "parameters": [{
+        "$ref": "../parameters.json#/checkoutIdPathParam"
+      }],
+      "produces": ["application/json"],
+      "responses": {
+        "200": {
+          "description": "Updated borrower's checkout",
+          "schema": { "$ref": "../definitions.json#/checkout" }
+        },
+        "401": {
+          "description": "Authentication required",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "403": {
+          "description": "Cannot renew checkout",
+          "schema": { "$ref": "../definitions.json#/error" }
+        },
+        "404": {
+          "description": "Checkout not found",
+          "schema": { "$ref": "../definitions.json#/error" }
+        },
+        "500": {
+          "description": "Internal error",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "503": {
+          "description": "Under maintenance",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        }
+      },
+      "x-koha-authorization": {
+        "allow-owner": true,
+        "allow-guarantor": true,
+        "permissions": {
+          "circulate": "circulate_remaining_permissions"
+        }
+      }
+    }
+  },
+  "/checkouts/{checkout_id}/renewability": {
+    "get": {
+      "x-mojo-to": "Checkout#renewability",
+      "operationId": "renewabilityCheckout",
+      "tags": ["patrons", "checkouts"],
+      "parameters": [{
+          "name": "checkout_id",
+          "in": "path",
+          "description": "Internal checkout identifier",
+          "required": true,
+          "type": "integer"
+      }],
+      "produces": ["application/json"],
+      "responses": {
+        "200": {
+          "description": "Checkout renewability",
+          "schema": { "$ref": "../definitions.json#/renewability" }
+        },
+        "401": {
+          "description": "Authentication required",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "schema": { "$ref": "../definitions.json#/error" }
+        },
+        "404": {
+          "description": "Checkout not found",
+          "schema": { "$ref": "../definitions.json#/error" }
+        },
+        "500": {
+          "description": "Internal error",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "503": {
+          "description": "Under maintenance",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        }
+      }
+    }
+  },
+  "/checkouts/history": {
+    "get": {
+      "x-mojo-to": "Checkout#listhistory",
+      "operationId": "listhistoryCheckouts",
+      "tags": ["patrons", "checkouts"],
+      "parameters": [
+        { "$ref": "../parameters.json#/borrowernumberQueryParam" }
+      ],
+      "produces": [
+        "application/json"
+      ],
+      "responses": {
+        "200": {
+          "description": "A list of checkouts history",
+          "schema": {
+            "$ref": "../definitions.json#/checkouts"
+          }
+        },
+        "401": {
+          "description": "Authentication required",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "403": {
+          "description": "Access forbidden",
+          "schema": { "$ref": "../definitions.json#/error" }
+        },
+        "404": {
+          "description": "Borrower not found",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "500": {
+          "description": "Internal error",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "503": {
+          "description": "Under maintenance",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        }
+      },
+      "x-koha-authorization": {
+        "allow-owner": true,
+        "allow-guarantor": true,
+        "permissions": {
+          "circulate_remaining_permissions": "1"
+        }
+      }
+    }
+  },
+  "/checkouts/history/{checkout_id}": {
+    "get": {
+      "x-mojo-to": "Checkout#gethistory",
+      "operationId": "gethistoryCheckout",
+      "tags": ["patrons", "checkouts"],
+      "parameters": [
+        { "$ref": "../parameters.json#/checkoutIdPathParam" }
+      ],
+      "produces": ["application/json"],
+      "responses": {
+        "200": {
+          "description": "Got borrower's checkout",
+          "schema": { "$ref": "../definitions.json#/checkout" }
+        },
+        "401": {
+          "description": "Authentication required",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "403": {
+          "description": "Access forbidden",
+          "schema": { "$ref": "../definitions.json#/error" }
+        },
+        "404": {
+          "description": "Checkout not found",
+          "schema": { "$ref": "../definitions.json#/error" }
+        },
+        "500": {
+          "description": "Internal error",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "503": {
+          "description": "Under maintenance",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        }
+      },
+      "x-koha-authorization": {
+        "allow-owner": true,
+        "allow-guarantor": true,
+        "permissions": {
+          "circulate_remaining_permissions": "1"
+        }
+      }
+    }
+  }
+}

--- a/t/spec/koha-swagger/paths/cities.json
+++ b/t/spec/koha-swagger/paths/cities.json
@@ -1,0 +1,275 @@
+{
+  "/cities": {
+    "get": {
+      "x-mojo-to": "Cities#list",
+      "operationId": "list",
+      "tags": ["cities"],
+      "produces": [
+        "application/json"
+      ],
+      "parameters": [{
+        "name": "city_name",
+        "in": "query",
+        "description": "Case insensative 'starts-with' search on city name",
+        "required": false,
+        "type": "string"
+      }, {
+        "name": "city_state",
+        "in": "query",
+        "description": "Case insensative 'starts-with' search on city state",
+        "required": false,
+        "type": "string"
+      }, {
+        "name": "city_country",
+        "in": "query",
+        "description": "Case insensative 'starts_with' search on city country",
+        "required": false,
+        "type": "string"
+      }, {
+        "name": "city_zipcode",
+        "in": "query",
+        "description": "Case Insensative 'starts-with' search on zipcode",
+        "required": false,
+        "type": "string"
+      }],
+      "responses": {
+        "200": {
+          "description": "A list of cities",
+          "schema": {
+            "type": "array",
+            "items": {
+              "$ref": "../definitions.json#/city"
+            }
+          }
+        },
+        "403": {
+          "description": "Access forbidden",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "500": {
+          "description": "Internal error",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "503": {
+          "description": "Under maintenance",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        }
+      }
+    },
+    "post": {
+      "x-mojo-to": "Cities#add",
+      "operationId": "add",
+      "tags": ["cities"],
+      "parameters": [{
+        "name": "body",
+        "in": "body",
+        "description": "A JSON object containing informations about the new hold",
+        "required": true,
+        "schema": {
+          "$ref": "../definitions.json#/city"
+        }
+      }],
+      "produces": [
+        "application/json"
+      ],
+      "responses": {
+        "200": {
+          "description": "City added",
+          "schema": {
+            "$ref": "../definitions.json#/city"
+          }
+        },
+        "401": {
+          "description": "Authentication required",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "403": {
+          "description": "Access forbidden",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "500": {
+          "description": "Internal error",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "503": {
+          "description": "Under maintenance",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        }
+      },
+      "x-koha-authorization": {
+        "permissions": {
+          "parameters": "parameters_remaining_permissions"
+        }
+      }
+    }
+  },
+  "/cities/{cityid}": {
+    "get": {
+      "x-mojo-to": "Cities#get",
+      "operationId": "get",
+      "tags": ["cities"],
+      "parameters": [{
+        "$ref": "../parameters.json#/cityidPathParam"
+      }],
+      "produces": [
+        "application/json"
+      ],
+      "responses": {
+        "200": {
+          "description": "A city",
+          "schema": {
+            "$ref": "../definitions.json#/city"
+          }
+        },
+        "404": {
+          "description": "City not found",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "500": {
+          "description": "Internal error",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "503": {
+          "description": "Under maintenance",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        }
+      }
+    },
+    "put": {
+      "x-mojo-to": "Cities#update",
+      "operationId": "update",
+      "tags": ["cities"],
+      "parameters": [{
+        "$ref": "../parameters.json#/cityidPathParam"
+      }, {
+        "name": "body",
+        "in": "body",
+        "description": "A JSON object containing informations about the new hold",
+        "required": true,
+        "schema": {
+          "$ref": "../definitions.json#/city"
+        }
+      }],
+      "produces": [
+        "application/json"
+      ],
+      "responses": {
+        "200": {
+          "description": "A city",
+          "schema": {
+            "$ref": "../definitions.json#/city"
+          }
+        },
+        "401": {
+          "description": "Authentication required",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "403": {
+          "description": "Access forbidden",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "404": {
+          "description": "City not found",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "500": {
+          "description": "Internal error",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "503": {
+          "description": "Under maintenance",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        }
+      },
+      "x-koha-authorization": {
+        "permissions": {
+          "parameters": "parameters_remaining_permissions"
+        }
+      }
+    },
+    "delete": {
+      "x-mojo-to": "Cities#delete",
+      "operationId": "delete",
+      "tags": ["cities"],
+      "parameters": [{
+        "$ref": "../parameters.json#/cityidPathParam"
+      }],
+      "produces": [
+        "application/json"
+      ],
+      "responses": {
+        "200": {
+          "description": "City deleted",
+          "schema": {
+            "type": "string"
+          }
+        },
+        "401": {
+          "description": "Authentication required",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "403": {
+          "description": "Access forbidden",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "404": {
+          "description": "City not found",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "500": {
+          "description": "Internal error",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "503": {
+          "description": "Under maintenance",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        }
+      },
+      "x-koha-authorization": {
+        "permissions": {
+          "parameters": "parameters_remaining_permissions"
+        }
+      }
+    }
+  }
+}

--- a/t/spec/koha-swagger/paths/holds.json
+++ b/t/spec/koha-swagger/paths/holds.json
@@ -1,0 +1,395 @@
+{
+  "/holds": {
+    "get": {
+      "x-mojo-to": "Hold#list",
+      "operationId": "listHolds",
+      "tags": ["patrons", "holds"],
+      "parameters": [
+        {
+          "name": "reserve_id",
+          "in": "query",
+          "description": "Internal reserve identifier",
+          "type": "integer"
+        },
+        {
+          "$ref": "../parameters.json#/borrowernumberQueryParam"
+        },
+        {
+          "name": "reservedate",
+          "in": "query",
+          "description": "Reserve date",
+          "type": "string"
+        },
+        {
+          "name": "biblionumber",
+          "in": "query",
+          "description": "Internal biblio identifier",
+          "type": "integer"
+        },
+        {
+          "name": "branchcode",
+          "in": "query",
+          "description": "Branch code",
+          "type": "string"
+        },
+        {
+          "name": "notificationdate",
+          "in": "query",
+          "description": "Notification date",
+          "type": "string"
+        },
+        {
+          "name": "reminderdate",
+          "in": "query",
+          "description": "Reminder date",
+          "type": "string"
+        },
+        {
+          "name": "cancellationdate",
+          "in": "query",
+          "description": "Cancellation date",
+          "type": "string"
+        },
+        {
+          "name": "reservenotes",
+          "in": "query",
+          "description": "Reserve notes",
+          "type": "string"
+        },
+        {
+          "name": "priority",
+          "in": "query",
+          "description": "Priority",
+          "type": "integer"
+        },
+        {
+          "name": "found",
+          "in": "query",
+          "description": "Found status",
+          "type": "string"
+        },
+        {
+          "name": "timestamp",
+          "in": "query",
+          "description": "Time of latest update",
+          "type": "string"
+        },
+        {
+          "name": "itemnumber",
+          "in": "query",
+          "description": "Internal item identifier",
+          "type": "integer"
+        },
+        {
+          "name": "waitingdate",
+          "in": "query",
+          "description": "Date the item was marked as waiting for the patron",
+          "type": "string"
+        },
+        {
+          "name": "expirationdate",
+          "in": "query",
+          "description": "Date the hold expires",
+          "type": "string"
+        },
+        {
+          "name": "lowestPriority",
+          "in": "query",
+          "description": "Lowest priority",
+          "type": "integer"
+        },
+        {
+          "name": "suspend",
+          "in": "query",
+          "description": "Suspended",
+          "type": "integer"
+        },
+        {
+          "name": "suspend_until",
+          "in": "query",
+          "description": "Suspended until",
+          "type": "string"
+        }
+      ],
+      "produces": ["application/json"],
+      "responses": {
+        "200": {
+          "description": "A list of holds",
+          "schema": {
+            "$ref": "../definitions.json#/holds"
+          }
+        },
+        "401": {
+          "description": "Authentication required",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "403": {
+          "description": "Hold not allowed",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "404": {
+          "description": "Borrower not found",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "500": {
+          "description": "Internal server error",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "503": {
+          "description": "Under maintenance",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        }
+      },
+      "x-koha-authorization": {
+        "allow-owner": true,
+        "allow-guarantor": true,
+        "permissions": {
+          "borrowers": "1"
+        }
+      }
+    },
+    "post": {
+      "x-mojo-to": "Hold#add",
+      "operationId": "addHold",
+      "tags": ["patrons", "holds"],
+      "parameters": [{
+          "name": "body",
+          "in": "body",
+          "description": "A JSON object containing informations about the new hold",
+          "required": true,
+          "schema": {
+            "type": "object",
+            "properties": {
+              "borrowernumber": {
+                "description": "Borrower internal identifier",
+                "type": "integer"
+              },
+              "biblionumber": {
+                "description": "Biblio internal identifier",
+                "type": "integer"
+              },
+              "itemnumber": {
+                "description": "Item internal identifier",
+                "type": "integer"
+              },
+              "branchcode": {
+                "description": "Pickup location",
+                "type": "string"
+              },
+              "expirationdate": {
+                "description": "Hold end date",
+                "type": "string",
+                "format": "date"
+              }
+            }
+          }
+        }
+      ],
+      "consumes": ["application/json"],
+      "produces": ["application/json"],
+      "responses": {
+        "201": {
+          "description": "Created hold",
+          "schema": {
+            "$ref": "../definitions.json#/hold"
+          }
+        },
+        "400": {
+          "description": "Missing or wrong parameters",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "401": {
+          "description": "Authentication required",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "403": {
+          "description": "Hold not allowed",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "404": {
+          "description": "Borrower not found",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "500": {
+          "description": "Internal server error",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "503": {
+          "description": "Under maintenance",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        }
+      },
+      "x-koha-authorization": {
+        "allow-owner": true,
+        "permissions": {
+          "reserveforothers": "1"
+        }
+      }
+    }
+  },
+  "/holds/{reserve_id}": {
+    "put": {
+      "x-mojo-to": "Hold#edit",
+      "operationId": "editHold",
+      "tags": ["holds"],
+      "parameters": [{
+          "$ref": "../parameters.json#/holdIdPathParam"
+        }, {
+          "name": "body",
+          "in": "body",
+          "description": "A JSON object containing fields to modify",
+          "required": true,
+          "schema": {
+            "type": "object",
+            "properties": {
+              "priority": {
+                "description": "Position in waiting queue",
+                "type": "integer",
+                "minimum": 1
+              },
+              "branchcode": {
+                "description": "Pickup location",
+                "type": "string"
+              },
+              "suspend_until": {
+                "description": "Suspend until",
+                "type": "string",
+                "format": "date"
+              }
+            }
+          }
+        }
+      ],
+      "consumes": ["application/json"],
+      "produces": ["application/json"],
+      "responses": {
+        "200": {
+          "description": "Updated hold",
+          "schema": {
+            "$ref": "../definitions.json#/hold"
+          }
+        },
+        "400": {
+          "description": "Missing or wrong parameters",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "401": {
+          "description": "Authentication required",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "403": {
+          "description": "Hold not allowed",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "404": {
+          "description": "Hold not found",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "500": {
+          "description": "Internal server error",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "503": {
+          "description": "Under maintenance",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        }
+      },
+      "x-koha-authorization": {
+        "allow-owner": true,
+        "allow-guarantor": true,
+        "permissions": {
+          "reserveforothers": "1"
+        }
+      }
+    },
+    "delete": {
+      "x-mojo-to": "Hold#delete",
+      "operationId": "deleteHold",
+      "tags": ["holds"],
+      "parameters": [{
+          "$ref": "../parameters.json#/holdIdPathParam"
+        }
+      ],
+      "produces": ["application/json"],
+      "responses": {
+        "200": {
+          "description": "Successful deletion",
+          "schema": {
+            "type": "object"
+          }
+        },
+        "401": {
+          "description": "Authentication required",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "403": {
+          "description": "Cancellation forbidden",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "404": {
+          "description": "Hold not found",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "500": {
+          "description": "Internal server error",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "503": {
+          "description": "Under maintenance",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        }
+      },
+      "x-koha-authorization": {
+        "allow-owner": true,
+        "allow-guarantor": true,
+        "permissions": {
+          "reserveforothers": "1"
+        }
+      }
+    }
+  }
+}

--- a/t/spec/koha-swagger/paths/items.json
+++ b/t/spec/koha-swagger/paths/items.json
@@ -1,0 +1,47 @@
+{
+  "/items/{itemnumber}": {
+    "get": {
+      "x-mojo-to": "Item#get",
+      "operationId": "getItem",
+      "tags": ["items"],
+      "parameters": [{
+          "$ref": "../parameters.json#/itemnumberPathParam"
+        }
+      ],
+      "consumes": ["application/json"],
+      "produces": ["application/json"],
+      "responses": {
+        "200": {
+          "description": "An item",
+          "schema": {
+            "$ref": "../definitions.json#/item"
+          }
+        },
+        "400": {
+          "description": "Missing or wrong parameters",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "404": {
+          "description": "Item not found",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "500": {
+          "description": "Internal error",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "503": {
+          "description": "Under maintenance",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        }
+      }
+    }
+  }
+}

--- a/t/spec/koha-swagger/paths/libraries.json
+++ b/t/spec/koha-swagger/paths/libraries.json
@@ -1,0 +1,79 @@
+{
+  "/libraries": {
+    "get": {
+      "x-mojo-to": "Library#list",
+      "operationId": "listLibrary",
+      "tags": ["libraries"],
+      "produces": [
+        "application/json"
+      ],
+      "responses": {
+        "200": {
+          "description": "A list of libraries",
+          "schema": {
+            "$ref": "../definitions.json#/libraries"
+          }
+        },
+        "500": {
+          "description": "Internal error",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "503": {
+          "description": "Under maintenance",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        }
+      }
+    }
+  },
+  "/libraries/{branchcode}": {
+    "get": {
+      "x-mojo-to": "Library#get",
+      "operationId": "getLibrary",
+      "tags": ["libraries"],
+      "parameters": [
+        {
+          "$ref": "../parameters.json#/branchcodePathParam"
+        }
+      ],
+      "produces": [
+        "application/json"
+      ],
+      "responses": {
+        "200": {
+          "description": "A library",
+          "schema": {
+            "$ref": "../definitions.json#/library"
+          }
+        },
+        "400": {
+          "description": "Bad parameter",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "404": {
+          "description": "Library not found",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "500": {
+          "description": "Internal error",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "503": {
+          "description": "Under maintenance",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        }
+      }
+    }
+  }
+}

--- a/t/spec/koha-swagger/paths/patrons.json
+++ b/t/spec/koha-swagger/paths/patrons.json
@@ -1,0 +1,555 @@
+{
+  "/patrons": {
+    "get": {
+      "x-mojo-to": "Patron#list",
+      "operationId": "listPatrons",
+      "tags": ["patrons"],
+      "parameters": [
+        { "$ref": "../parameters.json#/cardnumberQueryParam" },
+        { "$ref": "../parameters.json#/surnameQueryParam" },
+        { "$ref": "../parameters.json#/useridQueryParam" }
+      ],
+      "produces": [
+          "application/json"
+      ],
+      "responses": {
+        "200": {
+          "description": "A list of patrons",
+          "schema": {
+            "type": "array",
+            "items": {
+              "$ref": "../definitions.json#/patron"
+            }
+          }
+        },
+        "401": {
+          "description": "Authentication required",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "403": {
+          "description": "Access forbidden",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "500": {
+          "description": "Internal server error",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "503": {
+          "description": "Under maintenance",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        }
+      },
+      "x-koha-authorization": {
+        "permissions": {
+          "borrowers": "1"
+        }
+      }
+    },
+    "post": {
+      "x-mojo-to": "Patron#add",
+      "operationId": "addPatron",
+      "tags": ["patrons"],
+      "parameters": [{
+        "name": "body",
+        "in": "body",
+        "description": "A JSON object containing information about the new patron",
+        "required": true,
+        "schema": {
+          "$ref": "../definitions.json#/patron"
+        }
+      }],
+      "consumes": ["application/json"],
+      "produces": ["application/json"],
+      "responses": {
+        "201": {
+          "description": "A successfully created patron",
+          "schema": {
+            "items": {
+              "$ref": "../definitions.json#/patron"
+            }
+          }
+        },
+        "400": {
+          "description": "Bad parameter",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "401": {
+          "description": "Authentication required",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "403": {
+          "description": "Access forbidden",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "404": {
+          "description": "Resource not found",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "409": {
+          "description": "Conflict in creating resource",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "500": {
+          "description": "Internal error",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "503": {
+          "description": "Under maintenance",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        }
+      },
+      "x-koha-authorization": {
+        "permissions": {
+          "borrowers": "1"
+        }
+      }
+    }
+  },
+  "/patrons/{borrowernumber}": {
+    "get": {
+      "x-mojo-to": "Patron#get",
+      "operationId": "getPatron",
+      "tags": ["patrons"],
+      "parameters": [{
+        "$ref": "../parameters.json#/borrowernumberPathParam"
+      }],
+      "produces": [
+        "application/json"
+      ],
+      "responses": {
+        "200": {
+          "description": "A patron",
+          "schema": {
+            "$ref": "../definitions.json#/patron"
+          }
+        },
+        "401": {
+          "description": "Authentication required",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "403": {
+          "description": "Access forbidden",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "404": {
+          "description": "Patron not found",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "500": {
+          "description": "Internal server error",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "503": {
+          "description": "Under maintenance",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        }
+      },
+      "x-koha-authorization": {
+        "allow-owner": true,
+        "allow-guarantor": true,
+        "permissions": {
+          "borrowers": "1"
+        }
+      }
+    },
+    "put": {
+      "x-mojo-to": "Patron#edit",
+      "operationId": "editPatron",
+      "tags": ["patrons"],
+      "parameters": [
+        {
+          "$ref": "../parameters.json#/borrowernumberPathParam"
+        },
+        {
+          "name": "body",
+          "in": "body",
+          "description": "A JSON object containing new information about existing patron",
+          "required": true,
+          "schema": {
+            "$ref": "../definitions.json#/patron"
+          }
+        }
+      ],
+      "consumes": ["application/json"],
+      "produces": ["application/json"],
+      "responses": {
+        "200": {
+          "description": "A successfully updated patron",
+          "schema": {
+            "items": {
+              "$ref": "../definitions.json#/patron"
+            }
+          }
+        },
+        "202": {
+          "description": "Accepted and waiting for librarian verification",
+          "schema": {
+            "type": "object"
+          }
+        },
+        "204": {
+          "description": "No Content",
+          "schema": {
+            "type": "object"
+          }
+        },
+        "400": {
+          "description": "Bad parameter",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "401": {
+          "description": "Authentication required",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "403": {
+          "description": "Access forbidden",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "404": {
+          "description": "Resource not found",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "409": {
+          "description": "Conflict in updating resource",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "500": {
+          "description": "Internal error",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "503": {
+          "description": "Under maintenance",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        }
+      },
+      "x-koha-authorization": {
+        "allow-owner": true,
+        "allow-guarantor": true,
+        "permissions": {
+          "borrowers": "1"
+        }
+      }
+    },
+    "delete": {
+      "x-mojo-to": "Patron#delete",
+      "operationId": "deletePatron",
+      "tags": ["patrons"],
+      "parameters": [{
+        "$ref": "../parameters.json#/borrowernumberPathParam"
+      }],
+      "produces": ["application/json"],
+      "responses": {
+        "200": {
+          "description": "Patron deleted successfully",
+          "schema": {
+            "type": "object"
+          }
+        },
+        "400": {
+          "description": "Patron deletion failed",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "401": {
+          "description": "Authentication required",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "403": {
+          "description": "Access forbidden",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "404": {
+          "description": "Patron not found",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "500": {
+          "description": "Internal server error",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "503": {
+          "description": "Under maintenance",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        }
+      },
+      "x-koha-authorization": {
+        "permissions": {
+          "borrowers": "1"
+        }
+      }
+    }
+  },
+  "/patrons/{borrowernumber}/password": {
+    "patch": {
+      "x-mojo-to": "Patron#changepassword",
+      "operationId": "changepasswordPatron",
+      "tags": ["patrons"],
+      "parameters": [{
+          "$ref": "../parameters.json#/borrowernumberPathParam"
+        }, {
+          "name": "body",
+          "in": "body",
+          "description": "A JSON object containing informations about passwords",
+          "required": true,
+          "schema": {
+            "type": "object",
+            "properties": {
+              "current_password": {
+                "description": "Current password",
+                "type": "string"
+              },
+              "new_password": {
+                "description": "New password",
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
+      "produces": [
+          "application/json"
+      ],
+      "responses": {
+        "200": {
+          "description": "Password changed"
+        },
+        "400": {
+          "description": "Bad request",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "401": {
+          "description": "Authentication required",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "403": {
+          "description": "Access forbidden",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "404": {
+          "description": "Patron not found",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "500": {
+          "description": "Internal server error",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "503": {
+          "description": "Under maintenance",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        }
+      },
+      "x-koha-authorization": {
+        "allow-owner": true,
+        "permissions": {
+          "borrowers": "1"
+        }
+      }
+    }
+  },
+  "/patrons/{borrowernumber}/payment": {
+    "post": {
+      "x-mojo-to": "Patron#pay",
+      "operationId": "payForPatron",
+      "tags": ["accountlines"],
+      "produces": [
+        "application/json"
+      ],
+      "parameters": [
+        { "$ref": "../parameters.json#/borrowernumberPathParam" },
+        {
+          "name": "body",
+          "in": "body",
+          "description": "A JSON object containing fields to modify",
+          "required": true,
+          "schema": {
+            "type": "object",
+            "properties": {
+              "amount": {
+                "description": "Amount to pay",
+                "type": "number",
+                "exclusiveMinimum": true,
+                "minimum": 0
+              },
+              "note": {
+                "description": "Payment note",
+                "type": ["string", "null"]
+              }
+            },
+            "required": ["amount"]
+          }
+        }
+      ],
+      "consumes": ["application/json"],
+      "produces": ["application/json"],
+      "responses": {
+        "204": {
+          "description": "Success"
+        },
+        "400": {
+          "description": "Missing or wrong parameters",
+          "schema": { "$ref": "../definitions.json#/error" }
+        },
+        "401": {
+          "description": "Authentication required",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "403": {
+          "description": "Access forbidden",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "404": {
+          "description": "Borrower not found",
+          "schema": { "$ref": "../definitions.json#/error" }
+        },
+        "500": {
+          "description": "Internal server error",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "503": {
+          "description": "Under maintenance",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        }
+      },
+      "x-koha-authorization": {
+        "permissions": {
+          "updatecharges": "1"
+        }
+      }
+    }
+  },
+  "/patrons/{borrowernumber}/status": {
+    "get": {
+      "x-mojo-to": "Patron#getstatus",
+      "operationId": "getstatusPatron",
+      "tags": ["patrons"],
+      "parameters": [{
+          "$ref": "../parameters.json#/borrowernumberPathParam"
+        }
+      ],
+      "produces": [
+          "application/json"
+      ],
+      "responses": {
+        "200": {
+          "description": "A patron",
+          "schema": {
+            "$ref": "../definitions.json#/patronstatus"
+          }
+        },
+        "401": {
+          "description": "Authentication required",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "403": {
+          "description": "Access forbidden",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "404": {
+          "description": "Patron not found",
+          "schema": {
+           "$ref": "../definitions.json#/error"
+          }
+        },
+        "500": {
+          "description": "Internal server error",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "503": {
+          "description": "Under maintenance",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        }
+      },
+     "x-koha-authorization": {
+        "allow-owner": true,
+       "allow-guarantor": true,
+        "permissions": {
+          "borrowers": "1"
+        }
+      }
+    }
+  }
+}

--- a/t/spec/koha-swagger/swagger.json
+++ b/t/spec/koha-swagger/swagger.json
@@ -1,0 +1,28 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Koha REST API",
+    "version": "1",
+    "license": {
+      "name": "GPL v3",
+      "url": "http://www.gnu.org/licenses/gpl.txt"
+    },
+    "contact": {
+      "name": "Koha Development Team",
+      "url": "https://koha-community.org/"
+    }
+  },
+  "basePath": "/api/v1",
+  "paths": {
+    "$ref": "paths.json"
+  },
+  "definitions": {
+    "$ref": "definitions.json"
+  },
+  "parameters": {
+    "$ref": "parameters.json"
+  },
+  "x-primitives": {
+    "$ref": "x-primitives.json"
+  }
+}

--- a/t/spec/koha-swagger/x-primitives.json
+++ b/t/spec/koha-swagger/x-primitives.json
@@ -1,0 +1,47 @@
+{
+  "biblionumber": {
+    "type": "integer",
+    "description": "internally assigned biblio identifier"
+  },
+  "borrowernumber": {
+    "type": "integer",
+    "description": "internally assigned user identifier"
+  },
+  "branchcode": {
+    "type": "string",
+    "description": "a unique key assigned to each branch"
+  },
+  "cardnumber": {
+    "type": ["string", "null"],
+    "description": "library assigned user identifier"
+  },
+  "cityid": {
+    "type": "integer",
+    "description": "internally assigned city identifier",
+    "readOnly": true
+  },
+  "email": {
+    "type": ["string", "null"],
+    "description": "primary email address for patron's primary address"
+  },
+  "firstname": {
+    "type": ["string", "null"],
+    "description": "patron's first name"
+  },
+  "itemnumber": {
+    "type": ["integer", "null"],
+    "description": "internally assigned item identifier"
+  },
+  "phone": {
+    "type": ["string", "null"],
+    "description": "primary phone number for patron's primary address"
+  },
+  "reserve_id": {
+    "type": "integer",
+    "description": "Internal hold identifier"
+  },
+  "surname": {
+    "type": "string",
+    "description": "patron's last name"
+  }
+}


### PR DESCRIPTION
After migrating from Swagger2 to Mojolicious::Plugin::OpenAPI, we noticed that every now and then the requests to our API would fail in what seems to be a pretty random order. We figured out it has to do with $refs sometimes being unresolved.

The issue seems to occur in _resolve_schema which unintentionally skips an unresolved $ref. In order to avoid resolving same references twice or more, _resolve_schema has a functionality that stores the memory address of the reference to remember that it has already resolved it, but it seems that at some point that exact same memory address is freed for another reference and it would then get skipped.

I have created a test that replicates the original issue with our spec. I included our whole spec because I was not able to reproduce it with a smaller specification... Perhaps someone can come up with a better test and the first commit containing our whole API could be ignored? Please see the commit messages for more documentation. Thanks!