### PR TITLE
Replace Windows path separators with Unix path separators

### DIFF
--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -123,6 +123,7 @@ sub _build_formats {
 sub _load_schema {
   my ($self, $url, $parent) = @_;
   my ($namespace, $scheme) = ("$url", "file");
+  $namespace =~ s|\\|/|g if $^O eq 'MSWin32';
   my $doc;
 
   if ($namespace =~ $HTTP_SCHEME_RE) {


### PR DESCRIPTION
... so that the separators will not be URL-escaped afterwards, which then will let Cwd::abs_path crash (line 144), saying there's no such file or directory.

See http://www.cpantesters.org/cpan/report/ed0d39b3-6bfc-1014-941f-c7baf1edae7c for crash example.
