### PR TITLE
implement "const"

### DIFF
--- a/t/jv-const.t
+++ b/t/jv-const.t
@@ -1,0 +1,93 @@
+use lib '.';
+use t::Helper;
+
+# tests for "const"
+
+my $faithful = {
+    type => 'object',
+    properties => {
+        constancy => {
+            const => "as the northern star"
+       }
+    }
+};
+my $ambitious = {
+    type => 'object',
+    properties => {
+        constancy => {
+            const => "there is a tide in the affairs of men"
+        }
+    }
+};
+
+# the matches
+validate_ok {
+    name => "Caesar",
+    constancy => "as the northern star"
+}, $faithful;
+
+validate_ok {
+    name => "Brutus",
+    constancy => "there is a tide in the affairs of men"
+}, $ambitious;
+
+
+# the fails
+validate_ok {
+    name => "Cassius",
+    constancy => "Cassius from bondage will deliver Cassius"
+}, $faithful, E('/constancy', q{Does not match const: "as the northern star".});
+
+validate_ok {
+    name => "Calpurnia",
+    constancy => "Do not go forth today. Call it my fear That keeps you in the house"
+}, $ambitious, E('/constancy', q{Does not match const: "there is a tide in the affairs of men".});
+
+
+# now oneOf should work right
+# before the fix, this failed with:
+#     "All of the oneOf rules match."
+# because "likes: chocolate" vs. "peanutbutter" wasn't being considered
+my $schema = {
+    type => 'object',
+    properties => {
+        people => {
+            type => 'array',
+            items => {
+                oneOf => [
+                    { '$ref' => '#/definitions/chocolate' },
+                    { '$ref' => '#/definitions/peanutbutter' },
+                ],
+            },
+        },
+    },
+    definitions => {
+        chocolate => {
+            type => 'object',
+            properties => {
+                name  => { type => 'string' },
+                age   => { type => 'number' },
+                likes => { const => 'chocolate' },
+            },
+        },
+        peanutbutter => {
+            type => 'object',
+            properties => {
+                name  => { type => 'string' },
+                age   => { type => 'number' },
+                likes => { const => 'peanutbutter' },
+            },
+        },
+    },
+};
+validate_ok {
+    people => [
+        {
+            name => 'mr. chocolate fan',
+            age => 42,
+            likes => 'peanutbutter'
+        },
+    ],
+}, $schema;
+
+done_testing;


### PR DESCRIPTION
added in draft-wright-json-schema-validation-01

http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.24

I wasn't sure what the intent of the error-handling logic was in _validate_type_object, so I just copied the existing code covering "enum". Feel free to correct that or clean it up.