### PR TITLE
Don't checks data type, if data undefined

### DIFF
--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -340,10 +340,15 @@ sub _validate {
     push @errors, $self->_validate_any_of($data, $path, [map { +{%$schema, type => $_} } @$type]);
   }
   elsif ($type) {
-    my $method = sprintf '_validate_type_%s', $type;
-    @errors = $self->$method($data, $path, $schema);
-    warn "[JSON::Validator] type @{[$path||'/']} $method [@errors]\n" if DEBUG > 1;
-    return @errors if @errors;
+    if( defined $data){
+      my $method = sprintf '_validate_type_%s', $type;
+      @errors = $self->$method($data, $path, $schema);
+      warn "[JSON::Validator] type @{[$path||'/']} $method [@errors]\n" if DEBUG > 1;
+      return @errors if @errors;
+    }
+    else {
+      warn "[JSON::Validator] WARNING type @{[$path||'/']} is undefined, skip validation" if DEBUG > 1;
+    }
   }
 
   if (my $rules = $schema->{not}) {


### PR DESCRIPTION
I suggest not checking the data type if the data contains undefined

For schema
```
Family:
    type: object
    properties:
        id: 
            type: integer
        name: 
            type: string
        subname: 
            type: string
      required:
      - id
      - name
      - subname
```
does not pass validation:
```
{
    id => 1,
    name=>'name',
    subname=>undef,
}
```