### PR TITLE
Add support for EXPERIMENTAL mixins in spec

### DIFF
--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -304,7 +304,7 @@ sub _resolver {
     warn Data::Dumper::Dumper($look_in->data) if DEBUG and $ref =~ /\b[c]\b/;   # follow the changes
     my $data = $ref->fragment ? $look_in->get($ref->fragment) : $look_in->data;
     die qq[Possibly a typo in schema? Could not find "$ref"] unless $data;
-    $topic->{$_} = $data->{$_} for keys %$data;
+    $topic->{$_} ||= $data->{$_} for keys %$data;                               # allow mixins
     unshift @$refs, $topic if $topic->{'$ref'} and !ref $topic->{'$ref'};
     delete $topic->{id} if !ref $topic->{id} and $self->isa('JSON::Validator::OpenAPI');
   }

--- a/t/mixin.t
+++ b/t/mixin.t
@@ -1,0 +1,27 @@
+use Mojo::Base -strict;
+use Test::More;
+use JSON::Validator;
+
+my $jv = JSON::Validator->new;
+$jv->schema('data://main/spec.json');
+
+is $jv->schema->get('/properties/x'), 111,               'x';
+is $jv->schema->get('/properties/y'), 'in conflict',     'y';
+is $jv->schema->get('/properties/z'), 'not in conflict', 'z';
+
+done_testing;
+__DATA__
+@@ spec.json
+{
+  "properties": {
+    "y": "in conflict",
+    "z": "not in conflict",
+    "$ref": "#/definitions/again"
+  },
+  "definitions": {
+    "again": {
+      "x": 111,
+      "y": 222
+    }
+  }
+}

--- a/t/recursion.t
+++ b/t/recursion.t
@@ -1,5 +1,4 @@
 use Mojo::Base -strict;
-use Test::Mojo;
 use Test::More;
 use JSON::Validator 'validate_json';
 use JSON::Validator::OpenAPI;


### PR DESCRIPTION
This patch allow you to do this in M::P::OpenAPI: (Note the `allow_invalid_ref` parameter)

```
use Mojo::Base -strict;
use Test::Mojo;
use Test::More;

plan skip_all => 'TEST_MIXIN=1' unless $ENV{TEST_MIXIN};

use Mojolicious::Lite;
get '/mixin' => sub {
  my $c = shift->openapi->valid_input or return;
  $c->reply->openapi(200 => $c->openapi->spec);
  },
  'mixin';

plugin OpenAPI => {allow_invalid_ref => 1, url => 'data://main/main.json'};

my $t = Test::Mojo->new;
$t->get_ok('/api/mixin?age=34')->status_is(200)->json_is('/parameters/0/name', 'age');

done_testing;

__DATA__
@@ main.json
{
  "swagger" : "2.0",
  "info" : { "version": "0.8", "title" : "Array" },
  "basePath" : "/api",
  "paths" : {
    "/mixin" : {
      "get" : {
        "x-mojo-name" : "mixin",
        "parameters" : [
          {
            "name": "age",
            "$ref": "data://main/mixins.json#/definitions/p1"
          }
        ],
        "responses" : {
          "200": { "description": "Response", "schema": {"type":"object"} }
        }
      }
    }
  }
}

@@ mixins.json
{
  "definitions": {
    "p1": {"in": "query", "name": "x", "type": "integer"}
  }
}
```