### PR TITLE
Coerce integer numbers into booleans

### DIFF
--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -527,7 +527,7 @@ sub _validate_type_boolean {
 
   if (  defined $value
     and $self->{coerce}{booleans}
-    and (B::svref_2object(\$value)->FLAGS & B::SVp_NOK or $value =~ /^(true|false)$/))
+    and (B::svref_2object(\$value)->FLAGS & (B::SVp_IOK | B::SVp_NOK) or $value =~ /^(true|false)$/))
   {
     $_[1] = $value ? Mojo::JSON->true : Mojo::JSON->false;
     return;

--- a/t/booleans.t
+++ b/t/booleans.t
@@ -6,6 +6,8 @@ my $schema = {properties => {v => {type => 'boolean'}}};
 
 validate_ok {v => '0'},     $schema, E('/v', 'Expected boolean - got string.');
 validate_ok {v => 'false'}, $schema, E('/v', 'Expected boolean - got string.');
+validate_ok {v => 1},       $schema, E('/v', 'Expected boolean - got number.');
+validate_ok {v => 0.5},     $schema, E('/v', 'Expected boolean - got number.');
 validate_ok {v => Mojo::JSON->true},  $schema;
 validate_ok {v => Mojo::JSON->false}, $schema;
 
@@ -14,7 +16,8 @@ validate_ok {v => !!1},     $schema;
 validate_ok {v => !!0},     $schema;
 validate_ok {v => 'false'}, $schema;
 validate_ok {v => 'true'},  $schema;
-validate_ok {v => 1},       $schema, E('/v', 'Expected boolean - got number.');
+validate_ok {v => 1},       $schema;
+validate_ok {v => 0.5},     $schema;
 validate_ok {v => '1'},     $schema, E('/v', 'Expected boolean - got string.');
 validate_ok {v => '0'},     $schema, E('/v', 'Expected boolean - got string.');
 validate_ok {v => ''},      $schema, E('/v', 'Expected boolean - got string.');

--- a/t/jv-boolean.t
+++ b/t/jv-boolean.t
@@ -1,15 +1,12 @@
 use lib '.';
 use t::Helper;
-use Test::More;
-use utf8;
-use JSON;
 
 my $schema = {
   type       => 'object',
   properties => {nick => {type => 'boolean'}}
 };
 
-validate_ok {nick => JSON::true}, $schema;
+validate_ok {nick => true}, $schema;
 validate_ok {nick => 1000},       $schema, E('/nick', 'Expected boolean - got number.');
 validate_ok {nick => 0.5},        $schema, E('/nick', 'Expected boolean - got number.');
 validate_ok {nick => 'nick'},     $schema, E('/nick', 'Expected boolean - got string.');

--- a/t/jv-boolean.t
+++ b/t/jv-boolean.t
@@ -1,0 +1,31 @@
+use lib '.';
+use t::Helper;
+use Test::More;
+use utf8;
+use JSON;
+
+my $schema = {
+  type       => 'object',
+  properties => {nick => {type => 'boolean'}}
+};
+
+validate_ok {nick => JSON::true}, $schema;
+validate_ok {nick => 1000},       $schema, E('/nick', 'Expected boolean - got number.');
+validate_ok {nick => 0.5},        $schema, E('/nick', 'Expected boolean - got number.');
+validate_ok {nick => 'nick'},     $schema, E('/nick', 'Expected boolean - got string.');
+validate_ok {nick => bless({}, 'BoolTest')},   $schema;
+validate_ok {nick => bless({}, 'BoolTestNegative')},   $schema, E('/nick', 'Expected boolean - got BoolTestNegative.');
+
+t::Helper->validator->coerce(1);
+validate_ok {nick => 1000}, $schema;
+validate_ok {nick => 0.5}, $schema;
+
+done_testing;
+
+package BoolTest;
+
+use overload '""' => sub { 1 };
+
+package BoolTestNegative;
+
+use overload '""' => sub { 2 };


### PR DESCRIPTION
This intends to solve issue #56 , so that, when coerce is on, integer numbers are coerced into booleans, just like real numbers are currently.

It also adds a test case for boolean types. Currently master fails one test case (when coerce is on and the value is 1000), the code in this pull request succeeds