### PR TITLE
When caching / resolving a schema avoid the case where $namespace is just a fragment  [ Fixes issue #65 ]

### DIFF
--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -323,7 +323,9 @@ sub _seen {
 
 sub _store {
   my ($self, $key, $namespace, $schema) = @_;
-  $namespace = Mojo::URL->new($namespace)->fragment(undef)->to_string;
+  if (Mojo::URL->new($namespace)->to_string ne "#".(Mojo::URL->new($namespace)->fragment // "")) {
+      $namespace = Mojo::URL->new($namespace)->fragment(undef)->to_string;
+  }
   return $self->{$key}{$namespace} unless $schema;
   return $self->{$key}{$namespace} = $schema;
 }

--- a/t/draft4-tests/refRemote.json
+++ b/t/draft4-tests/refRemote.json
@@ -50,6 +50,65 @@
         ]
     },
     {
+        "description": "ref within object property",
+        "schema": {
+            "type": "object",
+            "properties": {
+                 "objectInner": {
+                    "$ref":"http://localhost:1234/object.json"
+                 }
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "object with right property inside valid",
+                "data": {"objectInner" : {"okay_property" : 1}},
+                "valid": true
+            },
+            {
+                "description": "object with wrong property outside invalid",
+                "data": {"x" : {}},
+                "valid": false
+            },
+            {
+                "description": "object with wrong property outside invalid",
+                "data": { "objectInner" : {"x" : {}}},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ref within object property with id",
+        "schema": {
+            "type": "object",
+            "id": "#objectOuter",
+            "properties": {
+                 "objectInner": {
+                    "$ref":"http://localhost:1234/object.json"
+                 }
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "object with right property inside valid",
+                "data": {"objectInner" : {"okay_property" : 1}},
+                "valid": true
+            },
+            {
+                "description": "object with wrong property outside invalid",
+                "data": {"x" : {}},
+                "valid": false
+            },
+            {
+                "description": "object with wrong property outside invalid",
+                "data": { "objectInner" : {"x" : {}}},
+                "valid": false
+            }
+        ]
+    },
+    {
         "description": "change resolution scope",
         "schema": {
             "id": "http://localhost:1234/",

--- a/t/remotes/object.json
+++ b/t/remotes/object.json
@@ -1,0 +1,8 @@
+{
+	"type":"object",
+	"id":"#objectWithProperty",
+	"properties":{
+		"okay_property":{}
+	},
+	"additionalProperties": false
+}


### PR DESCRIPTION
This reinstates the support of remote schemas where every document has an id that is just a fragment.

I ran the test suite on a variant of this with debugger statements, https://github.com/wbazant/json-validator/commit/184bcda2810fbace8f05ae9e35f71220b18f1a5e , and logs said the change didn't touch execution paths covered by the suite apart from the two new tests.
Without the head commit, the first test succeeds and the second one fails. In 1.0.3, they both fail.

It won't be helpful until resolving https://github.com/jhthorsen/json-validator/issues/74 and bringing back support for remote schemas that have ids - and if it adds support for remote schemas that have ids that also reference each other, this PR would have become obsolete.

