### PR TITLE
Better booleans handling in OpenAPI

### DIFF
--- a/lib/JSON/Validator/OpenAPI.pm
+++ b/lib/JSON/Validator/OpenAPI.pm
@@ -83,7 +83,12 @@ sub validate_request {
         $value += 0;
       }
       elsif ($type eq 'boolean') {
-        $value = (!$value or $value eq 'false') ? Mojo::JSON->false : Mojo::JSON->true;
+        if (!$value or $value =~ /^(?:false|off)$/) {
+          $value = Mojo::JSON->false;
+        }
+        elsif ($value =~ /^(?:1|true|on)$/) {
+          $value = Mojo::JSON->true;
+        }
       }
     }
 

--- a/t/openapi-request.t
+++ b/t/openapi-request.t
@@ -138,6 +138,34 @@ validate_request(
   }
 );
 
+# valid booleans
+$c->tx->req(Mojo::Message::Request->new)->req->url->parse('http://127.0.0.1/?a=&b=0&c=false&x=true&y=1&z=on');
+validate_request(
+  {
+    parameters => [
+      map { +{name => $_, type => 'boolean', in => 'query'} } qw/a b c x y z/,
+    ],
+  },
+  sub {
+    is "@_", "", "valid request";
+    is_deeply $input, {a => false, b => false, c => false, x => true, y => true, z => true}, 'valid booleans';
+  }
+);
+
+# invalid booleans
+$c->tx->req(Mojo::Message::Request->new)->req->url->parse('http://127.0.0.1/?a=something&b=2&c=TRUE');
+validate_request(
+  {
+    parameters => [
+      map { +{name => $_, type => 'boolean', in => 'query'} } qw/a b c/,
+    ],
+  },
+  sub {
+    like "@_", qr{\Q/a: Expected boolean - got string. /b: Expected boolean - got string. /c: Expected boolean - got string.\E}, "invalid request";
+    is_deeply $input, {}, 'nothing in input';
+  }
+);
+
 done_testing;
 
 sub make_request {


### PR DESCRIPTION
If a user passes invalid boolean values in request, no errors will be generated.

For instance, for the schema:
```
parameters => [
  {name => "param", type => 'boolean', in => 'query'},
],
```
And requests:
`GET /index?param=FALSE`
or
`GET /index?param=INVALID`

the `param` will be provided to a controller with "true" value, which is not correct.

With this PR it will be correct only with boolean's coercion turned on.
