### PR TITLE
Validate headers regardless of case

### DIFF
--- a/t/openapi-request.t
+++ b/t/openapi-request.t
@@ -138,6 +138,32 @@ validate_request(
   }
 );
 
+# headers
+$c->tx->req(Mojo::Message::Request->new)->req->headers
+  ->header('X-Custom' => 123)
+  ->header('X-DATA' => 'something');
+validate_request(
+  {
+    parameters => [
+      {name => 'x-custom', type => 'integer', required => 1, in => 'header'},
+      {name => 'X-Data', type => 'string', required => 1, in => 'header'},
+    ]
+  },
+  sub {
+    is "@_", "", "valid headers";
+    is_deeply $input, {'x-custom' => 123, 'X-Data' => 'something'}, 'headers are correct';
+  }
+);
+
+# missing header
+make_request('application/json', qq([]));
+validate_request(
+  {parameters => [{name => 'x-custom', type => 'string', required => 1, in => 'header'}]},
+  sub {
+    like "@_", qr{\Q/x-custom: Expected string - got null.\E}, "the header is missing";
+  }
+);
+
 done_testing;
 
 sub make_request {


### PR DESCRIPTION
HTTP headers are defined as case-insensitive and probably should be validated using this rule.

RFC 7230 (https://tools.ietf.org/html/rfc7230#section-3.2) 
RFC 2616 (https://tools.ietf.org/html/rfc2616#section-4.2)
