### PR TITLE
Can load $ref from file:/

### DIFF
--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -219,15 +219,18 @@ sub _load_schema {
     return $self->_load_schema_from_text(\$url), '';
   }
 
-  my $file = $url;
-  $file =~ s!#$!!;
-  $file = path(split '/', $file);
-  if (-e $file) {
-    $file = $file->realpath;
-    warn "[JSON::Validator] Loading schema from file: $file\n" if DEBUG;
-    return $self->_load_schema_from_text(\$file->slurp), $url;
-  }
-  elsif ($file =~ m!^/!) {
+
+  if ($url =~ m!file://(.*)!) {
+    my $file = $1;
+    $file =~ s!#$!!;
+    $file = path(split '/', $file);
+
+    if (-e $file) {
+      $file = $file->realpath;
+      warn "[JSON::Validator] Loading schema from file: $file\n" if DEBUG;
+      return $self->_load_schema_from_text(\$file->slurp), $url;
+    }
+  } elsif ($url =~ m!^/!) {
     warn "[JSON::Validator] Loading schema from URL $url\n" if DEBUG;
     return $self->_load_schema_from_url(Mojo::URL->new($url)->fragment(undef)), "$url";
   }


### PR DESCRIPTION
Hello.
I have a problem with "$ref" which is defined as "file://...".
I tried to specify "$ref" as an absolute path, in various combinations with "id" -- nothing worked.

If there is another way (not using "file://"), tell me please.
If it is a bug, this PR should fix it.