### PR TITLE
fix bug coerce numbers vs negative/fraction/exp

### DIFF
--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -521,7 +521,7 @@ sub _validate_type_number {
     and $value * 0 == 0)
   {
     return E $path, "Expected $expected - got string."
-      if !$self->{coerce}{numbers} or $value =~ /\D/;
+      if !$self->{coerce}{numbers} or $value !~ /^-?\d+(?:[.]\d+)?(?:e[+-]\d+)?$/smxi;
     $_[1] = 0 + $value;    # coerce input value
   }
 

--- a/t/jv-coerce-numbers.t
+++ b/t/jv-coerce-numbers.t
@@ -1,0 +1,33 @@
+use Mojo::Base -strict;
+use Test::More;
+use JSON::Validator;
+
+my $strict_validator = JSON::Validator->new;
+my $coerce_validator = JSON::Validator->new->coerce({numbers => 1});
+
+my $schema
+  = {type => 'object', properties => {mynumber => {type => 'number'}}};
+
+my @errors = $strict_validator->validate({mynumber => -1}, $schema);
+is "@errors", "", "strict -1";
+
+@errors = $strict_validator->validate({mynumber => '-1'}, $schema);
+is "@errors", '/mynumber: Expected number - got string.', "strict '-1'";
+
+@errors = $coerce_validator->validate({mynumber => -1}, $schema);
+is "@errors", "", "coerce -1";
+
+@errors = $coerce_validator->validate({mynumber => '-1'}, $schema);
+is "@errors", "", "coerce '-1'";
+
+@errors = $coerce_validator->validate({mynumber => '-1.41'}, $schema);
+is "@errors", "", "coerce '-1.41'";
+
+@errors = $coerce_validator->validate({mynumber => '-1.41e-29'}, $schema);
+is "@errors", "", "coerce '-1.41e-29'";
+
+@errors = $coerce_validator->validate({mynumber => '-1.41pi-29'}, $schema);
+is "@errors", '/mynumber: Expected number - got string.', "coerce '-1.41pi-29'";
+
+done_testing;
+__END__


### PR DESCRIPTION
Fix for Bug: when coerce numbers is on, only non-negative integers are validated.