### PR TITLE
Depend on Mojolicious>=7.28

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,5 +1,5 @@
 # You can install this projct with curl -L http://cpanmin.us | perl - https://github.com/jhthorsen/json-validator/archive/master.tar.gz
-requires "Mojolicious" => "7.15";
+requires "Mojolicious" => "7.28";
 
 recommends "Cpanel::JSON::XS"       => "3.02";
 recommends "Data::Validate::Domain" => "0.10";


### PR DESCRIPTION
a8cd35e4a8a8548c30997a5be2d2409fc23449dd added a call to Mojo::File::realpath, that was introduced in Mojolicious 7.28. In practice, this means that now everything depends on Mojolicious>=7.28