### PR TITLE
Correctly identify local fqn when bundling

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for perl distribution JSON-Validator
 
+2.01 Not Released
+ - Fix bundle method not spotting "local" fqn when schema from URL
+
 2.00 2018-01-19T10:36:23+0100
  - Fix validating against any enum value #22
  - Require YAML::XS 0.67 for proper boolean handling

--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -85,7 +85,7 @@ sub bundle {
       my $ref  = ref $from;
 
       if ($ref eq 'HASH' and my $tied = tied %$from) {
-        return $from if $tied->fqn =~ m!^\#!;
+        return $from if $tied->fqn =~ m!^$self->{root_schema_url}\#!;
         my $name = $self->$def_name_cb($tied->fqn);
         push @topics, [$tied->schema, $bundle->{definitions}{$name} = {}];
         tie my %ref, 'JSON::Validator::Ref', $tied->schema, "#/definitions/$name";

--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -66,7 +66,7 @@ sub bundle {
   my @topics = ([undef, my $bundle = {}]);
   my ($cloner, $tied);
 
-  $topics[0][0] = $args->{schema} ? $self->_reset->_resolve($args->{schema}) : $self->schema->data;
+  $topics[0][0] = $args->{schema} ? $self->_resolve($args->{schema}) : $self->schema->data;
 
   if ($args->{replace}) {
     $cloner = sub {
@@ -152,7 +152,7 @@ sub get {
 
 sub load_and_validate_schema {
   my ($self, $spec, $args) = @_;
-  $spec = $self->_reset->_resolve($spec);
+  $spec = $self->_resolve($spec);
   my @errors = $self->new(%$self)->schema($args->{schema} || SPECIFICATION_URL)->validate($spec);
   confess join "\n", "Invalid JSON specification $spec:", map {"- $_"} @errors if @errors;
   $self->{schema} = Mojo::JSON::Pointer->new($spec);
@@ -162,7 +162,7 @@ sub load_and_validate_schema {
 sub schema {
   my $self = shift;
   return $self->{schema} unless @_;
-  $self->{schema} = Mojo::JSON::Pointer->new($self->_reset->_resolve(shift));
+  $self->{schema} = Mojo::JSON::Pointer->new($self->_resolve(shift));
   return $self;
 }
 
@@ -328,17 +328,14 @@ sub _report_schema {
   push @{$self->{report}}, [(('  ') x $self->{grouped}) . ('<<<'), $path || '/', $type, D $schema];
 }
 
-sub _reset {
-  delete $_[0]->{schemas}{''};
-  $_[0]->{level} = 0;
-  $_[0];
-}
-
 # _resolve() method is used to convert all "id" into absolute URLs and
 # resolve all the $ref's that we find inside JSON Schema specification.
 sub _resolve {
   my ($self, $schema) = @_;
   my ($id, $resolved, @refs);
+
+  local $self->{level} = $self->{level} || 0;
+  delete $_[0]->{schemas}{''} unless $self->{level};
 
   if (ref $schema eq 'HASH') {
     $id = $schema->{id} // '';
@@ -352,11 +349,13 @@ sub _resolve {
     $id = $schema->{id} if $schema->{id};
   }
 
-  if (!$self->{level}++ and my $id = $schema->{id}) {
-    confess "Root schema cannot have a fragment in the 'id'. ($id)" if $id =~ /\#./;
-    confess "Root schema cannot have a relative 'id'. ($id)" if $id and $id !~ /^\w+:/;
+  unless ($self->{level}) {
+    my $rid = $self->{root_schema_url} = $schema->{id} // $id;
+    confess "Root schema cannot have a fragment in the 'id'. ($rid)" if $rid and $rid =~ /\#./;
+    confess "Root schema cannot have a relative 'id'. ($rid)" if $rid and $rid !~ /^\w+:/;
   }
 
+  $self->{level}++;
   $self->_register_schema($schema, $id);
 
   my @topics = ([$schema, Mojo::URL->new($id)]);

--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -350,12 +350,13 @@ sub _resolve {
   }
 
   unless ($self->{level}) {
-    my $rid = $self->{root_schema_url} = $schema->{id} // $id;
+    my $rid = $schema->{id} // $id;
     if ($rid) {
       confess "Root schema cannot have a fragment in the 'id'. ($rid)" if $rid =~ /\#./;
       confess "Root schema cannot have a relative 'id'. ($rid)"
         unless $rid =~ /^\w+:/ or -e $rid or $rid =~ m!^/!;
     }
+    $self->{root_schema_url} = $rid;
   }
 
   $self->{level}++;

--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -351,8 +351,11 @@ sub _resolve {
 
   unless ($self->{level}) {
     my $rid = $self->{root_schema_url} = $schema->{id} // $id;
-    confess "Root schema cannot have a fragment in the 'id'. ($rid)" if $rid and $rid =~ /\#./;
-    confess "Root schema cannot have a relative 'id'. ($rid)" if $rid and $rid !~ /^\w+:/;
+    if ($rid) {
+      confess "Root schema cannot have a fragment in the 'id'. ($rid)" if $rid =~ /\#./;
+      confess "Root schema cannot have a relative 'id'. ($rid)"
+        unless $rid =~ /^\w+:/ or -e $rid or $rid =~ m!^/!;
+    }
   }
 
   $self->{level}++;

--- a/t/bundle.t
+++ b/t/bundle.t
@@ -1,6 +1,7 @@
 use Mojo::Base -strict;
 use Test::More;
 use JSON::Validator;
+use File::Spec;
 
 my $validator = JSON::Validator->new;
 my $bundled;
@@ -45,6 +46,16 @@ is $validator->schema->get('/name/$ref'), '#/definitions/name', 'schema get /nam
 
 $bundled = $validator->schema('data://main/api.json')->bundle;
 is_deeply [ sort keys %{ $bundled->{definitions} } ], [ 'objtype' ], 'no dup definitions';
+
+my $file
+  = File::Spec->catfile(File::Basename::dirname(__FILE__), 'spec', 'with-deep-mixed-ref.json');
+$bundled = $validator->schema($file)->bundle;
+is_deeply [ sort keys %{ $bundled->{definitions} } ], [qw(
+  _t_definitions_age_json
+  _t_definitions_unit_json
+  _t_definitions_weight_json
+  height
+)], 'right definitions in disk spec';
 
 done_testing;
 

--- a/t/bundle.t
+++ b/t/bundle.t
@@ -43,4 +43,28 @@ is $validator->get('/name/$ref'), undef,    'get /name/$ref';
 is $validator->schema->get('/name/type'), 'string',             'schema get /name/type';
 is $validator->schema->get('/name/$ref'), '#/definitions/name', 'schema get /name/$ref';
 
+$bundled = $validator->schema('data://main/api.json')->bundle;
+is_deeply [ sort keys %{ $bundled->{definitions} } ], [ 'objtype' ], 'no dup definitions';
+
 done_testing;
+
+__DATA__
+
+@@ api.json
+{
+   "definitions" : {
+      "objtype" : {
+         "type" : "object",
+         "properties" : { "propname" : { "type" : "string" } }
+      }
+   },
+   "paths" : {
+      "/withdots" : {
+         "get" : {
+            "responses" : {
+               "200" : { "schema" : { "$ref" : "#/definitions/objtype" } }
+            }
+         }
+      }
+   }
+}


### PR DESCRIPTION
Currently, for an OpenAPI schema got from a URL, including a `data:` one, the `fqn` stored in the `JSON::Validator::Ref` contains the URL, which is fine. Unfortunately the `bundle` method special-cases as "local" only `$ref`s that begin with `#`, and does not spot them as "local" if they have the URL.

This patch generalises the "local" check to "starts with the local `fqn`, which might be empty-string".