### PR TITLE
Fix multitype enum validation inside an allOf

### DIFF
--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -558,6 +558,7 @@ sub _validate_type_enum {
   my $m    = S $data;
 
   for my $i (@$enum) {
+    return if $m eq S(undef) && S($i) eq S('null');
     return if $m eq S $i;
   }
 


### PR DESCRIPTION
Fixes regression starting in v2.00 where an enum containing a type constraint of `["string","null"]` would not accept return values ( from Mojolicious::Plugin::OpenAPI ) of `undef` as valid if inside an allOf.