### PR TITLE
Test problem seen when directory name has RFC 3986 reserved chars

### DIFF
--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -437,7 +437,7 @@ sub _resolve_ref {
   return if tied %$topic;
 
   my $other = $topic;
-  my ($base, $fqn, $pointer, $ref, @guard);
+  my ($location, $fqn, $pointer, $ref, @guard);
 
   while (1) {
     $ref = $other->{'$ref'};
@@ -445,16 +445,16 @@ sub _resolve_ref {
     confess "Seems like you have a circular reference: @guard" if @guard > RECURSION_LIMIT;
     last if !$ref or ref $ref;
     $fqn = $ref =~ m!^/! ? "#$ref" : $ref;
-    ($base, $pointer) = split /#/, $fqn, 2;
-    $url = $base = _location_to_abs($base, $url);
-    $pointer = undef if length $base and !length $pointer;
+    ($location, $pointer) = split /#/, $fqn, 2;
+    $url = $location = _location_to_abs($location, $url);
+    $pointer = undef if length $location and !length $pointer;
     $pointer = url_unescape $pointer if defined $pointer;
-    $fqn = join '#', grep defined, $base, $pointer;
-    $other = $self->_resolve($base);
+    $fqn = join '#', grep defined, $location, $pointer;
+    $other = $self->_resolve($location);
 
     if (defined $pointer and length $pointer) {
       $other = Mojo::JSON::Pointer->new($other)->get($pointer)
-        or confess qq[Possibly a typo in schema? Could not find "$pointer" in "$base" ($ref)];
+        or confess qq[Possibly a typo in schema? Could not find "$pointer" in "$location" ($ref)];
     }
   }
 

--- a/t/bundle.t
+++ b/t/bundle.t
@@ -67,7 +67,7 @@ for my $pathlist (@pathlists) {
       height
       )
     ],
-    'right definitions in disk spec';
+    'right definitions in disk spec' or diag explain $bundled->{definitions};
 }
 
 # this test mimics what Mojolicious::Plugin::OpenAPI does when loading
@@ -79,6 +79,13 @@ my $file2 = path(path(__FILE__)->dirname, 'spec', File::Spec->updir, 'spec', 'bu
 $bundled = $openapi->schema($file2)->bundle;
 eval { $openapi->load_and_validate_schema($bundled) };
 is $@, '', 'bundled schema is valid';
+
+# ensure filenames with funny characters not mangled by Mojo::URL
+my $file3 = path(__FILE__)->sibling('spec', 'space bundle.json');
+eval { $bundled = $validator->schema($file3)->bundle };
+is $@, '', 'loaded absolute filename with space';
+is $bundled->{properties}{age}{description}, 'Age in years',
+  'right definitions in disk spec' or diag explain $bundled;
 
 done_testing;
 

--- a/t/definitions/space age.json
+++ b/t/definitions/space age.json
@@ -1,0 +1,5 @@
+{
+  "type": "integer",
+  "minimum": 0,
+  "description": "Age in years"
+}

--- a/t/spec/space bundle.json
+++ b/t/spec/space bundle.json
@@ -1,0 +1,6 @@
+{
+  "type": "object",
+  "properties": {
+    "age": { "$ref": "../definitions/space age.json#" }
+  }
+}


### PR DESCRIPTION
The "definitions" file has a space here. I am using this to reproduce the problem that shows up (thanks to the call to `Mojo::File::realpath`) when any character that `Mojo::URL` percent-encodes is present anywhere in the full directory path. This is because the encoded version is then used as if it is a viable filesystem location, but it is not due to the encoding.