### PR TITLE
Fix strict for object issues

### DIFF
--- a/lib/JSON/Validator/Joi.pm
+++ b/lib/JSON/Validator/Joi.pm
@@ -98,7 +98,7 @@ sub _compile_object {
   my $self = shift;
   my $json = {type => $self->type};
 
-  $json->{additionalItems}   = false               if $self->{strict};
+  $json->{additionalProperties}   = false               if $self->{strict};
   $json->{maxProperties}     = $self->{max}        if defined $self->{max};
   $json->{minProperties}     = $self->{min}        if defined $self->{min};
   $json->{patternProperties} = $self->{regex}      if $self->{regex};

--- a/t/joi.t
+++ b/t/joi.t
@@ -5,7 +5,7 @@ use Test::More;
 
 is_deeply(
   edj(
-    joi->object->props(
+    joi->object->strict->props(
       age       => joi->integer->min(0)->max(200),
       alphanum  => joi->alphanum->length(12),
       color     => joi->string->min(2)->max(12)->pattern('^\w+$'),
@@ -37,6 +37,7 @@ is_deeply(
       uc        => {type => 'string', pattern   => '^\p{Uppercase}*$'},
       uri       => {type => 'string', format    => 'uri'},
     },
+    additionalProperties => false
   },
   'generated correct object schema'
 );


### PR DESCRIPTION
In Validator.pm line 763, you check if "additionalProperties" exists in $schema but in Joi.pm you create a "additionalItems" key when "strict" is used.
As the additionalProperties key is never created, the strict option never works.