### PR TITLE
protect against XXE DOS attacks on external refs

### DIFF
--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -243,6 +243,8 @@ sub _load_schema {
   $file = path(split '/', $file);
   if (-e $file) {
     $file = $file->realpath;
+    confess "Unable to load schema due to potential XXE attack vector: $file"
+      if $file =~ m!^/dev/!;
     warn "[JSON::Validator] Loading schema from file: $file\n" if DEBUG;
     return $self->_load_schema_from_text(\$file->slurp), CASE_TOLERANT ? lc $file : $file;
   }

--- a/t/load-xxe.t
+++ b/t/load-xxe.t
@@ -1,0 +1,32 @@
+use lib '.';
+use t::Helper;
+use Test::More;
+use Mojo::Path;
+
+my $path = Mojo::File->new('/dev/random')
+  ->to_rel( Mojo::File->new->path );
+
+my $schema = qq{{
+  "type": "object",
+  "properties": {
+    "age": { "\$ref": "$path#" }
+  }
+}};
+
+my $parsed = 0;
+
+eval {
+  alarm 5;
+  my $validator = t::Helper->validator->cache_paths([]);
+  validate_ok {}, $schema;
+  $parsed = 1;
+  alarm 0;
+};
+
+like(
+  $@,
+  qr!Unable to load schema due to potential XXE attack vector: /dev/random!,
+ 'no DOS due to XXE attack vector'
+);
+
+done_testing;


### PR DESCRIPTION
there's a new(ish) kind of DOS attack in the OWASP top ten: XXE[1],
where referring to an external entity that never returns can lead to DOS
attacks when parsing XML documents as they try to load those
never-ending external entities.

although they refer to XML there, it's pretty clear this can also affect
JSON-Schema and here's a test case that shows this. the fix has been
made in Validator.pm to prevent loading of files from /dev - this is a
pretty crude fix, which perhaps should be replaced with something more
generic like a timeout?

note there are more interesting attacks if we reference /etc/passwd:

    Can't use string ("nobody:*:-2:-2:Unprivileged User"...) as a
        HASH ref while "strict refs" in use at
        lib/JSON/Validator.pm line 269.

this is probably to discuss, but for now here's a trivial test case +
crude fix that show the POC in action

[1] https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Processing