### PR TITLE
Replacing 'id' keyword with '$id', as mandated by JSON schema Draft 07.

### DIFF
--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -357,7 +357,7 @@ sub _resolve {
   delete $_[0]->{schemas}{''} unless $self->{level};
 
   if (ref $schema eq 'HASH') {
-    $id = $schema->{id} // '';
+    $id = $schema->{'$id'} // '';
     return $resolved if $resolved = $self->{schemas}{$id};
   }
   elsif ($resolved = $self->{schemas}{$schema // ''}) {
@@ -365,11 +365,11 @@ sub _resolve {
   }
   else {
     ($schema, $id) = $self->_load_schema($schema);
-    $id = $schema->{id} if $schema->{id};
+    $id = $schema->{'$id'} if $schema->{'$id'};
   }
 
   unless ($self->{level}) {
-    my $rid = $schema->{id} // $id;
+    my $rid = $schema->{'$id'} // $id;
     if ($rid) {
       confess "Root schema cannot have a fragment in the 'id'. ($rid)" if $rid =~ /\#./;
       confess "Root schema cannot have a relative 'id'. ($rid)"
@@ -394,8 +394,8 @@ sub _resolve {
     elsif (UNIVERSAL::isa($topic, 'HASH')) {
       push @refs, [$topic, $base] and next if $topic->{'$ref'} and !ref $topic->{'$ref'};
 
-      if ($topic->{id} and !ref $topic->{id}) {
-        my $fqn = Mojo::URL->new($topic->{id});
+      if ($topic->{'$id'} and !ref $topic->{'$id'}) {
+        my $fqn = Mojo::URL->new($topic->{'$id'});
         $fqn = $fqn->to_abs($base) unless $fqn->is_abs;
         $self->_register_schema($topic, $fqn->to_string);
       }
@@ -770,7 +770,7 @@ sub _validate_type_object {
     # Special case used internally when validating schemas: This module adds "id"
     # on the top level which might conflict with very strict schemas, so we have to
     # remove it again unless there's a rule.
-    local $rules{id} = 1 if !$path and exists $data->{id};
+    local $rules{'$id'} = 1 if !$path and exists $data->{'$id'};
 
     if (my @k = grep { !$rules{$_} } @dkeys) {
       local $" = ', ';

--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -357,7 +357,7 @@ sub _resolve {
   delete $_[0]->{schemas}{''} unless $self->{level};
 
   if (ref $schema eq 'HASH') {
-    $id = $schema->{'$id'} // '';
+    $id = _get_id($schema) // '';
     return $resolved if $resolved = $self->{schemas}{$id};
   }
   elsif ($resolved = $self->{schemas}{$schema // ''}) {
@@ -365,11 +365,11 @@ sub _resolve {
   }
   else {
     ($schema, $id) = $self->_load_schema($schema);
-    $id = $schema->{'$id'} if $schema->{'$id'};
+    $id = _get_id($schema) if _get_id($schema);
   }
 
   unless ($self->{level}) {
-    my $rid = $schema->{'$id'} // $id;
+    my $rid = _get_id($schema) // $id;
     if ($rid) {
       confess "Root schema cannot have a fragment in the 'id'. ($rid)" if $rid =~ /\#./;
       confess "Root schema cannot have a relative 'id'. ($rid)"
@@ -394,8 +394,8 @@ sub _resolve {
     elsif (UNIVERSAL::isa($topic, 'HASH')) {
       push @refs, [$topic, $base] and next if $topic->{'$ref'} and !ref $topic->{'$ref'};
 
-      if ($topic->{'$id'} and !ref $topic->{'$id'}) {
-        my $fqn = Mojo::URL->new($topic->{'$id'});
+      if (_get_id($topic) and !ref _get_id($topic)) {
+        my $fqn = Mojo::URL->new(_get_id($topic));
         $fqn = $fqn->to_abs($base) unless $fqn->is_abs;
         $self->_register_schema($topic, $fqn->to_string);
       }
@@ -770,7 +770,7 @@ sub _validate_type_object {
     # Special case used internally when validating schemas: This module adds "id"
     # on the top level which might conflict with very strict schemas, so we have to
     # remove it again unless there's a rule.
-    local $rules{'$id'} = 1 if !$path and exists $data->{'$id'};
+    local $rules{'$id'} = 1 if !$path and _get_id($data);
 
     if (my @k = grep { !$rules{$_} } @dkeys) {
       local $" = ', ';
@@ -856,6 +856,13 @@ sub _expected {
   my $type = _guess_data_type($_[1]);
   return "Expected $_[0] - got different $type." if $_[0] =~ /\b$type\b/;
   return "Expected $_[0] - got $type.";
+}
+
+sub _get_id {
+  my $schema = shift;
+  return $schema->{'$id'} if $schema->{'$id'};
+  return $schema->{id} if $schema->{id};
+  return;
 }
 
 sub _guess_data_type {

--- a/t/bundle.t
+++ b/t/bundle.t
@@ -24,7 +24,7 @@ for my $n (1 .. 3) {
     name        => {'$ref' => '#/definitions/name'},
     age         => {'$ref' => 'b.json#/definitions/age'},
     definitions => {name   => {type => 'string'}},
-    B           => {id     => 'b.json', definitions => {age => {type => 'integer'}}},
+    B           => {'$id'  => 'b.json', definitions => {age => {type => 'integer'}}},
   })->bundle({ref_key => 'definitions'});
   is $bundled->{definitions}{name}{type}, 'string', "[$n] name still in definitions";
   is $bundled->{definitions}{b_json__definitions_age}{type}, 'integer', "[$n] added to definitions";


### PR DESCRIPTION
Fixing #114. Test case ``t/id-keyword.t`` fails with Mojo v6.15, however.