### PR TITLE
Make validate() return a list of errors when failing "allOf", closes #116

### DIFF
--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -1344,6 +1344,12 @@ Default is to use the value from the L</schema> attribute.
 
 =back
 
+=head2 errors_conf
+
+  $self = $self->errors_conf( complex_as_list => 1 );
+
+Set how to return the errors of C<validate> if it's a complex structure (all/any/oneOf and nested). The default is just one JSON::Validator::Error with C<message> concatenated.
+
 =head2 coerce
 
   $self = $self->coerce(booleans => 1, numbers => 1, strings => 1);

--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -114,6 +114,14 @@ sub bundle {
   return $bundle;
 }
 
+# $self->errors_conf( complex_as_list => 1 );
+sub errors_conf {
+  my $self = shift;
+  return $self->{errors_conf} ||= {} unless @_;
+  $self->{errors_conf} = ref $_[0] ? {%{$_[0]}} : {@_};
+  $self;
+}
+
 sub coerce {
   my $self = shift;
   return $self->{coerce} ||= {} unless @_;
@@ -529,7 +537,16 @@ sub _validate_all_of {
   my $expected = join ' or ', _uniq(@expected);
   return E $path, "allOf failed: Expected $expected, not $type."
     if $expected and @errors + @expected == @$rules;
-  return E $path, sprintf 'allOf failed: %s', _merge_errors(@errors) if @errors;
+
+  if (@errors) {
+    if ( $self->{errors_conf}->{complex_as_list} ) {
+        my @e = map {@$_} @errors;
+        return @e;
+    } else {
+      return E $path, sprintf 'allOf failed: %s', _merge_errors(@errors);
+    }
+  }
+
   return;
 }
 

--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -540,8 +540,7 @@ sub _validate_all_of {
 
   if (@errors) {
     if ( $self->{errors_conf}->{complex_as_list} ) {
-        my @e = map {@$_} @errors;
-        return @e;
+        return _flatten(@errors);
     } else {
       return E $path, sprintf 'allOf failed: %s', _merge_errors(@errors);
     }
@@ -1015,6 +1014,10 @@ sub _path {
 sub _uniq {
   my %uniq;
   grep { !$uniq{$_}++ } @_;
+}
+
+sub _flatten {
+  map { ref $_ eq 'ARRAY' ? _flatten(@{$_}) : $_ } @_;
 }
 
 # Please report if you need to manually monkey patch this function


### PR DESCRIPTION
This is a point of concept for getting each error for each proper parameter in complex structures. You just turn on an option to get all the errors in an individual JSON::Validator::Error