### PR TITLE
Will flatten allOf, anyOf and oneOf errors, closes #15 #116

### DIFF
--- a/t/issue-103-one-of.t
+++ b/t/issue-103-one-of.t
@@ -1,14 +1,10 @@
 use lib '.';
 use t::Helper;
-use Test::More;
 
-my $validator = JSON::Validator->new->schema('data://main/example.json');
-
-my @errors
-  = $validator->validate({who_id => 'WHO', expire => '2018-01-01', amount => 1000, desc => 'foo'});
-
-like "@errors", qr{oneOf failed}, "missing sym is not detected (@errors)";
-note map {"\$errors[] = $_\n"} @errors;
+validate_ok {who_id => 'WHO', expire => '2018-01-01', amount => 1000, desc => 'foo'},
+  'data://main/example.json', E('/sym', '/oneOf/0/allOf/0/allOf/0 Missing property.'),
+  E('/template', '/oneOf/0/allOf/2 Missing property.'),
+  E('/sym',      '/oneOf/1/allOf/0 Missing property.');
 
 done_testing;
 

--- a/t/jv-allof.t
+++ b/t/jv-allof.t
@@ -4,11 +4,11 @@ use t::Helper;
 my $schema = {allOf => [{type => 'string', maxLength => 5}, {type => 'string', minLength => 3}]};
 
 validate_ok 'short', $schema;
-validate_ok 12, $schema, E('/', 'allOf failed: Expected string, not number.');
+validate_ok 12, $schema, E('/', '/allOf Expected string, not number.');
 
 $schema = {allOf => [{type => 'string', maxLength => 7}, {type => 'string', maxLength => 5}]};
-validate_ok 'superlong', $schema,
-  E('/', 'allOf failed: String is too long: 9/7. String is too long: 9/5.');
-validate_ok 'toolong', $schema, E('/', 'allOf failed: String is too long: 7/5.');
+validate_ok 'superlong', $schema, E('/', '/allOf/0 String is too long: 9/7.'),
+  E('/', '/allOf/1 String is too long: 9/5.');
+validate_ok 'toolong', $schema, E('/', '/allOf/1 String is too long: 7/5.');
 
 done_testing;

--- a/t/jv-anyof.t
+++ b/t/jv-anyof.t
@@ -1,17 +1,16 @@
 use lib '.';
 use t::Helper;
 
-my $validator = JSON::Validator->new;
 my $schema = {anyOf => [{type => "string", maxLength => 5}, {type => "number", minimum => 0}]};
 
 validate_ok 'short',    $schema;
-validate_ok 'too long', $schema, E('/', 'anyOf failed: String is too long: 8/5.');
+validate_ok 'too long', $schema, E('/', '/anyOf/0 String is too long: 8/5.');
 validate_ok 12,         $schema;
-validate_ok - 1, $schema, E('/', 'anyOf failed: -1 < minimum(0)');
-validate_ok {}, $schema, E('/', 'anyOf failed: Expected string or number, got object.');
+validate_ok int(-1), $schema, E('/', '/anyOf/1 -1 < minimum(0)');
+validate_ok {}, $schema, E('/', '/anyOf Expected string or number, got object.');
 
 # anyOf with explicit integer (where _guess_data_type returns 'number')
-my $schemaB = {anyOf => [{type => "integer"}, {minimum => 2}]};
+my $schemaB = {anyOf => [{type => 'integer'}, {minimum => 2}]};
 validate_ok 1, $schemaB;
 
 validate_ok(
@@ -52,7 +51,8 @@ validate_ok(
     properties => {a => {type => 'number'}, b => {type => 'string'}},
     anyOf      => [{required => ['a']}, {required => ['b']}],
   },
-  E('/', 'anyOf failed: Missing property. Missing property.'),
+  E('/a', '/anyOf/0 Missing property.'),
+  E('/b', '/anyOf/1 Missing property.'),
 );
 
 done_testing;

--- a/t/jv-enum.t
+++ b/t/jv-enum.t
@@ -51,7 +51,7 @@ validate_ok(
     required   => ['name'],
     properties => {name => {type => ['string'], enum => [qw(n yes true false)]}},
   },
-  E('/name', 'anyOf failed: Expected string, got null.'),
+  E('/name', '/anyOf Expected string, got null.'),
   E('/name', 'Not in enum list: n, yes, true, false.'),
 );
 

--- a/t/jv-oneof.t
+++ b/t/jv-oneof.t
@@ -10,19 +10,20 @@ $schema = {oneOf => [{type => 'number', multipleOf => 5}, {type => 'number', mul
 validate_ok 10, $schema;
 validate_ok 9,  $schema;
 validate_ok 15, $schema, E('/', 'All of the oneOf rules match.');
-validate_ok 13, $schema, E('/', 'oneOf failed: Not multiple of 5. Not multiple of 3.');
+validate_ok 13, $schema, E('/', '/oneOf/0 Not multiple of 5.'),
+  E('/', '/oneOf/1 Not multiple of 3.');
 
 $schema = {oneOf => [{type => 'object'}, {type => 'string', multipleOf => 3}]};
-validate_ok 13, $schema, E('/', 'oneOf failed: Expected object or string, got number.');
+validate_ok 13, $schema, E('/', '/oneOf Expected object or string, got number.');
 
 $schema = {oneOf => [{type => 'object'}, {type => 'number', multipleOf => 3}]};
-validate_ok 13, $schema, E('/', 'oneOf failed: Not multiple of 3.');
+validate_ok 13, $schema, E('/', '/oneOf/1 Not multiple of 3.');
 
 # Alternative oneOf
 # http://json-schema.org/latest/json-schema-validation.html#anchor79
 $schema
   = {type => 'object', properties => {x => {type => ['string', 'null'], format => 'date-time'}}};
-validate_ok {x => 'foo'}, $schema, E('/x', 'anyOf failed: Does not match date-time format.');
+validate_ok {x => 'foo'}, $schema, E('/x', '/anyOf/0 Does not match date-time format.');
 validate_ok {x => '2015-04-21T20:30:43.000Z'}, $schema;
 validate_ok {x => undef}, $schema;
 


### PR DESCRIPTION
I think I was very wrong in https://github.com/jhthorsen/json-validator/issues/116#issuecomment-405523820 when I suggested adding "children" to JSON::Validator::Error, since it would make it a lot harder for the end user to figure out what was wrong.

I also think I've been previously wrong when I said that allOf, anyOf and oneOf should only return one error. I can't at this point not recall why I thought that was the only way.

This PR suggests that allOf, anyOf and oneOf will return a list of errors, one for each unique failure that happens. In addition, each failure message will be prefixed with a relative path to the validation object that made this fail.

Please review the changes in the test suite, since I think that will make it more obvious what is going on.

You, @biafra, @elowy01, @KES777, might be interested into having a look as well.

Does this change require a major version number bump?