### PR TITLE
Revert Mojolicious version dependency bump

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -9,7 +9,7 @@ my %WriteMakefileArgs = (
   EXE_FILES      => [qw()],
   BUILD_REQUIRES => {},
   TEST_REQUIRES  => {'Test::More' => '1.30'},
-  PREREQ_PM      => {'Mojolicious' => '8.00'},
+  PREREQ_PM      => {'Mojolicious' => '7.28'},
   META_MERGE     => {
     'dynamic_config' => 0,
     'meta-spec'      => {version => 2},

--- a/cpanfile
+++ b/cpanfile
@@ -1,5 +1,5 @@
 # You can install this projct with curl -L http://cpanmin.us | perl - https://github.com/jhthorsen/json-validator/archive/master.tar.gz
-requires "Mojolicious" => "8.00";
+requires "Mojolicious" => "7.28";
 
 recommends "Cpanel::JSON::XS"       => "3.02";
 recommends "Data::Validate::Domain" => "0.10";


### PR DESCRIPTION
The change to cope with the changed Mojo::URL->query() DWIM semantics
in Mojolicious 8.00 switched to using an explit ->merge() call, which
has worked the same way forever, so there's no need to bump the
required version of Mojolicious.