### PR TITLE
Improved validation of OpenAPI date format

### DIFF
--- a/lib/JSON/Validator/OpenAPI.pm
+++ b/lib/JSON/Validator/OpenAPI.pm
@@ -2,6 +2,7 @@ package JSON::Validator::OpenAPI;
 use Carp 'confess';
 use Mojo::Base 'JSON::Validator';
 use Mojo::Util;
+use Time::Local;
 use Scalar::Util ();
 
 use constant DEBUG             => $ENV{JSON_VALIDATOR_DEBUG} || 0;
@@ -289,7 +290,7 @@ sub _is_date {
   if (my ($year, $month, $day) = $date =~ m/^(\d{4})-(\d\d)-(\d\d)?$/) {
     $month--;
     local $@;
-    $validDate = eval { Time::Local::timegm(undef, undef, undef, $day, $month, $year); 1} || 0;
+    $validDate = eval { timegm(0, 0, 0, $day, $month, $year); 1} || 0;
   }
 
   return $validDate;

--- a/lib/JSON/Validator/OpenAPI.pm
+++ b/lib/JSON/Validator/OpenAPI.pm
@@ -280,7 +280,20 @@ sub _confess_invalid_in {
 }
 
 sub _is_byte_string { $_[0] =~ /^[A-Za-z0-9\+\/\=]+$/ }
-sub _is_date        { $_[0] =~ /^(\d+)-(\d+)-(\d+)$/ }
+
+sub _is_date {
+  my ($date) = @_;
+
+  my $validDate = 0;
+
+  if (my ($year, $month, $day) = $date =~ m/^(\d{4})-(\d\d)-(\d\d)?$/) {
+    $month--;
+    local $@;
+    $validDate = eval { Time::Local::timegm(undef, undef, undef, $day, $month, $year); 1} || 0;
+  }
+
+  return $validDate;
+}
 
 sub _is_number {
   return unless $_[0] =~ /^-?\d+(\.\d+)?$/;

--- a/lib/JSON/Validator/OpenAPI.pm
+++ b/lib/JSON/Validator/OpenAPI.pm
@@ -285,15 +285,15 @@ sub _is_byte_string { $_[0] =~ /^[A-Za-z0-9\+\/\=]+$/ }
 sub _is_date {
   my ($date) = @_;
 
-  my $validDate = 0;
+  my $valid_date = 0;
 
   if (my ($year, $month, $day) = $date =~ m/^(\d{4})-(\d\d)-(\d\d)?$/) {
     $month--;
     local $@;
-    $validDate = eval { timegm(0, 0, 0, $day, $month, $year); 1} || 0;
+    $valid_date = eval { timegm(0, 0, 0, $day, $month, $year); 1} || 0;
   }
 
-  return $validDate;
+  return $valid_date;
 }
 
 sub _is_number {

--- a/t/openapi-formats.t
+++ b/t/openapi-formats.t
@@ -17,6 +17,10 @@ my $schema = {type => 'object', properties => {v => {type => 'string'}}};
   $schema->{properties}{v}{format} = 'date';
   validate_ok {v => '2014-12-09'}, $schema;
   validate_ok {v => '2014-12-09T20:49:37Z'}, $schema, E('/v', 'Does not match date format.');
+  validate_ok {v => '09-12-2014'}, $schema, E('/v', 'Does not match date format.');
+  validate_ok {v => '09-DEC-2014'}, $schema, E('/v', 'Does not match date format.');
+  validate_ok {v => '09-DEC-14'}, $schema, E('/v', 'Does not match date format.');
+  validate_ok {v => '09/12/2014'}, $schema, E('/v', 'Does not match date format.');
 }
 
 {


### PR DESCRIPTION
Currently the OpenAPI `date` format validates against the regular expression pattern of `^(\d+)-(\d+)-(\d+)$` which allows a lot of common mistakes through (`31-01-1970`, `01-31-2014`, `31-13-1970`, etc).

I've added some additional tests to for the `date` format and updated the `_is_date` function in `JSON::Validator::OpenAPI` to have stricter validation rules based on RFC3339 (i.e. `YYYY-MM-DD`).