### PR TITLE
Fix broken link to json-schema.org examples

### DIFF
--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -1075,7 +1075,7 @@ JSON::Validator - Validate data against a JSON schema
   use JSON::Validator;
   my $validator = JSON::Validator->new;
 
-  # Define a schema - http://json-schema.org/examples.html
+  # Define a schema - http://json-schema.org/learn/miscellaneous-examples.html
   # You can also load schema from disk or web
   $validator->schema(
     {


### PR DESCRIPTION
Fixing broken URL in SYNOPSIS with a working link.

Not sure if this was the original page being linked to, but seemed to be the only one showing "examples" on json-schema.org ?

thanks,
Michael