### PR TITLE
Add support for translating error messages

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for perl distribution JSON-Validator
 
 3.00 Not Released
+ - Add support for translating error messages
  - Fix cases where input was not coerced
  - Changed how format validation is done
  - Changed Joi to always coerce values

--- a/lib/JSON/Validator/Error.pm
+++ b/lib/JSON/Validator/Error.pm
@@ -3,16 +3,33 @@ use Mojo::Base -base;
 
 use overload q("") => \&to_string, bool => sub {1}, fallback => 1;
 
+has message => sub {
+  my $self   = shift;
+  my $phrase = $self->phrase;
+  my $params = $self->phrase_parameters;
+
+  $phrase =~ s!%(\d+)\b!{$params->[$1 - 1] // $1}!ge;
+
+  return $phrase;
+};
+
+has path              => '/';
+has phrase            => '';
+has phrase_parameters => sub { [] };
+
 sub new {
-  my $self = bless {}, shift;
-  @$self{qw(path message)} = ($_[0] || '/', $_[1] || '');
-  $self;
+  my $self = shift->SUPER::new(ref $_[0] ? $_[0] : ());
+
+  unless (ref $_[0]) {
+    @$self{qw(path phrase)} = (shift || '/', shift || '');
+    $self->{phrase_parameters} = [@_];
+  }
+
+  return $self;
 }
 
-sub message   { shift->{message} }
-sub path      { shift->{path} }
-sub to_string { sprintf '%s: %s', @{$_[0]}{qw(path message)} }
-sub TO_JSON   { {message => $_[0]->{message}, path => $_[0]->{path}} }
+sub to_string { sprintf '%s: %s', $_[0]->path, $_[0]->message }
+sub TO_JSON { +{message => $_[0]->message, path => $_[0]->path} }
 
 1;
 
@@ -25,20 +42,91 @@ JSON::Validator::Error - JSON::Validator error object
 =head1 SYNOPSIS
 
   use JSON::Validator::Error;
-  my $err = JSON::Validator::Error->new($path, $message);
+  my $err = JSON::Validator::Error->new($path, $phrase, @phrase_parameters);
+
+  # Translate
+  $err->message(My::Lexicon->loc($err->phrase, @{$err->phrase_parameters});
 
 =head1 DESCRIPTION
 
 L<JSON::Validator::Error> is a class representing validation errors from
 L<JSON::Validator>.
 
+=head1 PHRASES
+
+=head2 Generic
+
+  Does not match %1 format.
+  Expected %1 - got %2.
+  Expected %1 - got different %2.
+  No validation rules defined.
+
+=head2 anyOf, allOf, oneOf, not
+
+  /allOf Expected %1 - got %2.
+  /anyOf Expected %1 - got %2.
+  /oneOf Expected %1 - got %2.
+  All of the oneOf rules match.
+  Should not match.
+
+=head2 Array
+
+  Invalid number of items: %1/%2.
+  Not enough items: %1/%2.
+  Too many items: %1/%2.
+  Unique items required.
+
+=head2 Constants
+
+  Does not match constant: %1.
+
+=head2 Enum
+
+  Not in enum list: %1.
+
+=head2 Formats
+
+  # uri
+  Hex escapes are not complete.
+  Invalid hex escape.
+  Path cannot be empty or begin with a /
+  Path cannot not start with //.
+  Scheme missing from URI.
+  Scheme must begin with a letter.
+  Scheme, path or fragment are required.
+
+=head2 Integers and numbers
+
+  %1 %2 maximum(%3)
+  %1 %2 minimum(%3)
+  Not multiple of %1.
+
+=head1 Null
+
+  Not null.
+
+=head2 Objects
+
+  Missing property.
+  Not enough properties: %1/%2.
+  Properties not allowed: %1.
+  Too many properties: %1/%2.
+
+=head2 String
+
+  String does not match %1.
+  String is too long: %1/%2.
+  String is too short: %1/%2.
+
 =head1 ATTRIBUTES
 
 =head2 message
 
-  my $str = $error->message;
+  my $str   = $error->message;
+  my $error = $error->message($str);
 
-A human readable description of the error. Defaults to empty string.
+A human readable description of the error. Defaults to the English version of
+L</phrase> filled with L</phrase_parameters>.
 
 =head2 path
 
@@ -46,11 +134,25 @@ A human readable description of the error. Defaults to empty string.
 
 A JSON pointer to where the error occurred. Defaults to "/".
 
+=head2 phrase
+
+  my $str = $error->phrase;
+
+Holds a phrase that can be translated and filled with L</phrase_parameters>.
+Example phrase: "Not enough items: %1/%2.".
+
+=head2 phrase_parameters
+
+  my $array_ref = $error->phrase_parameters;
+
+A list of values that can be put into the L</phrase>.
+
 =head1 METHODS
 
 =head2 new
 
-  my $error = JSON::Validator::Error->new($path, $message);
+  my $error = JSON::Validator::Error->new($path, $phrase, @$phrase_parameters);
+  my $error = JSON::Validator::Error->new(\%attributes);
 
 Object constructor.
 
@@ -58,7 +160,7 @@ Object constructor.
 
   my $str = $error->to_string;
 
-Returns the "path" and "message" part as a string: "$path: $message".
+Returns the L</path> and L</message> part as a string: C<$path: $message>.
 
 =head1 OPERATORS
 

--- a/t/jv-allof.t
+++ b/t/jv-allof.t
@@ -4,7 +4,7 @@ use t::Helper;
 my $schema = {allOf => [{type => 'string', maxLength => 5}, {type => 'string', minLength => 3}]};
 
 validate_ok 'short', $schema;
-validate_ok 12, $schema, E('/', '/allOf Expected string, not number.');
+validate_ok 12, $schema, E('/', '/allOf Expected string - got number.');
 
 $schema = {allOf => [{type => 'string', maxLength => 7}, {type => 'string', maxLength => 5}]};
 validate_ok 'superlong', $schema, E('/', '/allOf/0 String is too long: 9/7.'),

--- a/t/jv-anyof.t
+++ b/t/jv-anyof.t
@@ -7,7 +7,7 @@ validate_ok 'short',    $schema;
 validate_ok 'too long', $schema, E('/', '/anyOf/0 String is too long: 8/5.');
 validate_ok 12,         $schema;
 validate_ok int(-1), $schema, E('/', '/anyOf/1 -1 < minimum(0)');
-validate_ok {}, $schema, E('/', '/anyOf Expected string or number, got object.');
+validate_ok {}, $schema, E('/', '/anyOf Expected string/number - got object.');
 
 # anyOf with explicit integer (where _guess_data_type returns 'number')
 my $schemaB = {anyOf => [{type => 'integer'}, {minimum => 2}]};
@@ -45,7 +45,7 @@ validate_ok(
 );
 
 validate_ok(
-  {c => 'c present, a or b is missing'},
+  {c => 'c present, a/b is missing'},
   {
     type       => 'object',
     properties => {a => {type => 'number'}, b => {type => 'string'}},

--- a/t/jv-const.t
+++ b/t/jv-const.t
@@ -11,7 +11,7 @@ validate_ok {name => "Caesar", constancy => "as the northern star"}, $faithful;
 validate_ok {name => "Brutus", constancy => "there is a tide in the affairs of men"}, $ambitious;
 
 validate_ok {name => "Cassius", constancy => "Cassius from bondage will deliver Cassius"},
-  $faithful, E('/constancy', q{Does not match const: "as the northern star".});
+  $faithful, E('/constancy', q{Does not match constant: "as the northern star".});
 
 validate_ok(
   {
@@ -19,7 +19,7 @@ validate_ok(
     constancy => "Do not go forth today. Call it my fear That keeps you in the house"
   },
   $ambitious,
-  E('/constancy', q{Does not match const: "there is a tide in the affairs of men".})
+  E('/constancy', q{Does not match constant: "there is a tide in the affairs of men".})
 );
 
 # Now oneOf should work right

--- a/t/jv-enum.t
+++ b/t/jv-enum.t
@@ -51,7 +51,7 @@ validate_ok(
     required   => ['name'],
     properties => {name => {type => ['string'], enum => [qw(n yes true false)]}},
   },
-  E('/name', '/anyOf Expected string, got null.'),
+  E('/name', '/anyOf Expected string - got null.'),
   E('/name', 'Not in enum list: n, yes, true, false.'),
 );
 

--- a/t/jv-oneof.t
+++ b/t/jv-oneof.t
@@ -14,7 +14,7 @@ validate_ok 13, $schema, E('/', '/oneOf/0 Not multiple of 5.'),
   E('/', '/oneOf/1 Not multiple of 3.');
 
 $schema = {oneOf => [{type => 'object'}, {type => 'string', multipleOf => 3}]};
-validate_ok 13, $schema, E('/', '/oneOf Expected object or string, got number.');
+validate_ok 13, $schema, E('/', '/oneOf Expected object/string - got number.');
 
 $schema = {oneOf => [{type => 'object'}, {type => 'number', multipleOf => 3}]};
 validate_ok 13, $schema, E('/', '/oneOf/1 Not multiple of 3.');

--- a/t/phrases.t
+++ b/t/phrases.t
@@ -1,0 +1,40 @@
+use Mojo::Base -strict;
+use JSON::Validator::Error;
+use JSON::Validator;
+use Test::More;
+
+my %phrases;
+my $fh = Mojo::File->new($INC{'JSON/Validator.pm'})->open('<');
+while (<$fh>) {
+  next unless /E\s+[^,]+,\s*(.*)/;
+  my $phrase = $1;
+  next unless $phrase =~ s!.*?["']([^']+)['"].*!$1!;
+  next if $phrase eq '%1 %2';
+  note "found $phrase";
+  $phrases{$phrase} = ['validator'];
+}
+
+$fh = Mojo::File->new($INC{'JSON/Validator/Error.pm'})->open('<');
+my $record;
+while (<$fh>) {
+  last if /^=head1 ATTRIBUTES/;
+  next unless $record ||= /^=head1 PHRASES/;
+  next unless /^  ([^#].+)/;
+  note "documented $1";
+  push @{$phrases{$1}}, 'error';
+}
+
+for my $phrase (sort keys %phrases) {
+  if ($phrases{$phrase}[0] eq 'error') {
+    $fh = Mojo::File->new($INC{'JSON/Validator.pm'})->open('<');
+    while (<$fh>) {
+      next unless /'$phrase'/;
+      unshift @{$phrases{$phrase}}, 'validator';
+      last;
+    }
+  }
+
+  is_deeply $phrases{$phrase}, ['validator', 'error'], "documented $phrase";
+}
+
+done_testing;


### PR DESCRIPTION
To be able to merge this PR, I need at least someone to look over the phrases documented in JSON::Validator::Error.

I do however think it's a good idea for the format validators to return an array-ref, instead of a plain string.

Overview of PR:

* The changes in JSON::Validator is just to be compatible with the new JSON::Validator::Error API.
* The changes in JSON::Validator::Error is what is interesting.
* The changes in the tests should also be looked over.