### PR TITLE
Fix t/id-keyword-draft*.t test failures with Mojolicious 9.11 #242

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,7 @@ Revision history for perl distribution JSON-Validator
 4.15 Not Released
  - Removed deprecated functions joi() and validate_json()
  - Removed deprecated methods singleton() and version()
+ - Fix t/id-keyword-draft*.t test failures with Mojolicious 9.11 #242
 
 4.14 2021-02-23T14:58:07+0900
  - Add routes() to Schema::OpenAPIv2 and OpenAPIv3

--- a/t/id-keyword-draft4.t
+++ b/t/id-keyword-draft4.t
@@ -7,9 +7,9 @@ use Test::More;
 my ($base_url, $jv, $t, @e);
 
 use Mojolicious::Lite;
-get '/invalid-fragment'     => 'invalid-fragment';
-get '/invalid-relative'     => 'invalid-relative';
-get '/relative-to-the-root' => 'relative-to-the-root';
+get '/invalid-fragment'     => [format => ['json']] => 'invalid-fragment';
+get '/invalid-relative'     => [format => ['json']] => 'invalid-relative';
+get '/relative-to-the-root' => [format => ['json']] => 'relative-to-the-root';
 
 $t  = Test::Mojo->new;
 $jv = JSON::Validator->new(ua => $t->ua);

--- a/t/id-keyword-draft7.t
+++ b/t/id-keyword-draft7.t
@@ -6,8 +6,8 @@ use Test::More;
 my ($base_url, $jv, $t, @e);
 
 use Mojolicious::Lite;
-get '/person'           => 'person';
-get '/invalid-relative' => 'invalid-relative';
+get '/person'           => [format => ['json']] => 'person';
+get '/invalid-relative' => [format => ['json']] => 'invalid-relative';
 
 $t  = Test::Mojo->new;
 $jv = JSON::Validator->new(ua => $t->ua);


### PR DESCRIPTION
### Summary
Fix failing test with Mojolicious 9.11+

### References
#242 
