### PR TITLE
fix defaults for arrays with collectionFormat

### DIFF
--- a/lib/JSON/Validator/Schema/OpenAPIv2.pm
+++ b/lib/JSON/Validator/Schema/OpenAPIv2.pm
@@ -333,6 +333,7 @@ sub _validate_request_or_response {
   my @errors;
   for my $param (@$parameters) {
     my $val = $self->_get_parameter_value($param, $get);
+    $self->_coerce_parameter_format($val, $param) if $direction eq 'request';
     $self->_coerce_default_value($val, $param) unless $val->{exists};
 
     if ($param->{in} eq 'body') {
@@ -340,7 +341,6 @@ sub _validate_request_or_response {
       next;
     }
 
-    $self->_coerce_parameter_format($val, $param) if $direction eq 'request';
 
     if ($val->{exists}) {
       $self->_coerce_arrays($val, $param);

--- a/t/openapiv2-collection-format.t
+++ b/t/openapiv2-collection-format.t
@@ -50,15 +50,20 @@ __DATA__
     "/pets": {
       "get": {
         "parameters": [
+          {"name": "csv", "in": "query", "type": "array", "collectionFormat": "csv", "items": {"type": "number"}, "minItems": 0, "default": []},
           {"name": "csv0", "in": "query", "type": "array", "collectionFormat": "csv", "items": {"type": "number"}, "minItems": 0},
           {"name": "csv2", "in": "query", "type": "array", "collectionFormat": "csv", "items": {"type": "number"}, "minItems": 2},
+          {"name": "multi", "in": "query", "type": "array", "collectionFormat": "multi", "items": {"type": "integer"}, "minItems": 0, "default": []},
           {"name": "multi0", "in": "query", "type": "array", "collectionFormat": "multi", "items": {"type": "integer"}, "minItems": 0},
           {"name": "multi2", "in": "query", "type": "array", "collectionFormat": "multi", "items": {"type": "integer"}, "minItems": 2},
           {"name": "multir", "in": "query", "type": "array", "collectionFormat": "multi", "required": true, "items": {"type": "string"}, "minItems":1},
+          {"name": "pipes", "in": "query", "type": "array", "collectionFormat": "pipes", "items": {"type": "string"}, "minItems": 0, "default": []},
           {"name": "pipes0", "in": "query", "type": "array", "collectionFormat": "pipes", "items": {"type": "string"}, "minItems": 0},
           {"name": "pipes2", "in": "query", "type": "array", "collectionFormat": "pipes", "items": {"type": "integer"}, "minItems": 2},
+          {"name": "ssv", "in": "query", "type": "array", "collectionFormat": "ssv", "items": {"type": "number"}, "minItems": 0, "default": []},
           {"name": "ssv0", "in": "query", "type": "array", "collectionFormat": "ssv", "items": {"type": "number"}, "minItems": 0},
           {"name": "ssv2", "in": "query", "type": "array", "collectionFormat": "ssv", "items": {"type": "number"}, "minItems": 2},
+          {"name": "tsv", "in": "query", "type": "array", "collectionFormat": "tsv", "items": {"type": "integer"}, "minItems": 0, "default": []},
           {"name": "tsv0", "in": "query", "type": "array", "collectionFormat": "tsv", "items": {"type": "integer"}, "minItems": 0},
           {"name": "tsv2", "in": "query", "type": "array", "collectionFormat": "tsv", "items": {"type": "integer"}, "minItems": 2}
         ],


### PR DESCRIPTION
### Summary
Fixing defaults for arrays in query and path

### Motivation
Current implementation has a bug:
```yml
- name: elvishRingsOwners
  type: array
  items:
    type: string
  minItems: 1
  default: ["Gandalf", "Galadriel", "Cirdan"]
```
This schema cannot be validated if parameter is omitted.

### References
https://swagger.io/docs/specification/2-0/describing-parameters/#array-and-multi-value-parameters
there is an example of describing default value for array parameter
