### PR TITLE
fix joi required() with nested objects

### DIFF
--- a/lib/JSON/Validator/Joi.pm
+++ b/lib/JSON/Validator/Joi.pm
@@ -57,7 +57,8 @@ sub extend {
     $clone->{items} = dclone($by->{items}) if $by->{items};
   }
   elsif ($self->type eq 'object') {
-    $clone->{required} = [uniq @{$clone->{required}}, @{$by->{required}}] if ref $by->{required} eq 'ARRAY';
+    $clone->{required_props} = [uniq @{$clone->{required_props}}, @{$by->{required_props}}]
+      if defined $by->{required_props};
     $clone->{properties}{$_} = dclone($by->{properties}{$_}) for keys %{$by->{properties} || {}};
   }
 
@@ -82,7 +83,7 @@ sub props {
   my %properties = ref $_[0] ? %{$_[0]} : @_;
 
   while (my ($name, $property) = each %properties) {
-    push @{$self->{required}}, $name if $property->{required};
+    push @{$self->{required_props}}, $name if $property->{required};
     $self->{properties}{$name} = $property->compile;
   }
 
@@ -140,12 +141,12 @@ sub _compile_object {
   my $self = shift;
   my $json = {type => $self->type};
 
-  $json->{additionalProperties} = false               if $self->{strict};
-  $json->{maxProperties}        = $self->{max}        if defined $self->{max};
-  $json->{minProperties}        = $self->{min}        if defined $self->{min};
-  $json->{patternProperties}    = $self->{regex}      if $self->{regex};
-  $json->{properties}           = $self->{properties} if ref $self->{properties} eq 'HASH';
-  $json->{required}             = $self->{required}   if ref $self->{required} eq 'ARRAY';
+  $json->{additionalProperties} = false                   if $self->{strict};
+  $json->{maxProperties}        = $self->{max}            if defined $self->{max};
+  $json->{minProperties}        = $self->{min}            if defined $self->{min};
+  $json->{patternProperties}    = $self->{regex}          if $self->{regex};
+  $json->{properties}           = $self->{properties}     if ref $self->{properties} eq 'HASH';
+  $json->{required}             = $self->{required_props} if defined $self->{required_props};
 
   return $json;
 }

--- a/t/joi.t
+++ b/t/joi.t
@@ -87,6 +87,16 @@ for my $item ($strict_obj->compile, $strict_obj) {
   );
 }
 
+note "can omit non-required objects containing required properties";
+joi_ok({}, joi->object->props(a => joi->object->props(b => joi->integer->required)));
+
+note "must include required objects containing required properties";
+joi_ok(
+  {},
+  joi->object->props(a => joi->object->required->props(b => joi->integer->required)),
+  E('/a', 'Missing property.'),
+);
+
 eval { joi->number->extend(joi->integer) };
 like $@, qr{Cannot extend joi 'number' by 'integer'}, 'need to extend same type';
 


### PR DESCRIPTION
### Summary
This PR fixes Joi's required() method when used with nested objects.

### Motivation
Currently the `required` attribute is used for both the boolean flag of whether a property is required, and also to store the array of required properties. When used with nested objects, this either ends up with properties incorrectly being marked as required, or dying with `Can't use string ("1") as an ARRAY ref while "strict refs" in use`.

This PR moves the array of required properties into a separate attribute.