### PR TITLE
Allow unicode strings in the JSON schema

### DIFF
--- a/lib/JSON/Validator/Util.pm
+++ b/lib/JSON/Validator/Util.pm
@@ -24,7 +24,7 @@ sub E { JSON::Validator::Error->new(@_) }
 my $serializer = SEREAL_SUPPORT ? \&_sereal_encode : \&_yaml_dump;
 
 sub data_checksum {
-  return Mojo::Util::md5_sum(ref $_[0] ? $serializer->($_[0]) : defined $_[0] ? qq('$_[0]') : 'undef');
+  return Mojo::Util::md5_sum(ref $_[0] ? $serializer->($_[0]) : defined $_[0] ? do { utf8::encode(my $x = shift); qq('$x') } : 'undef');
 }
 
 sub data_section {

--- a/t/spec/with-unicode-multibyte.json
+++ b/t/spec/with-unicode-multibyte.json
@@ -2,7 +2,7 @@
   "type": "object",
   "properties": {
     "foo": {
-      "enum": ["foo–bar"]
+      "enum": ["foo♫bar"]
     }
   }
 }

--- a/t/spec/with-unicode-multibyte.json
+++ b/t/spec/with-unicode-multibyte.json
@@ -1,6 +1,9 @@
 {
   "type": "object",
   "properties": {
+    "bar": {
+      "enum": ["replacement�char"]
+    },
     "foo": {
       "enum": ["foo♫bar"]
     }

--- a/t/spec/with-unicode-multibyte.json
+++ b/t/spec/with-unicode-multibyte.json
@@ -1,0 +1,8 @@
+{
+  "type": "object",
+  "properties": {
+    "foo": {
+      "enum": ["foo–bar"]
+    }
+  }
+}

--- a/t/spec/with-unicode-multibyte.yml
+++ b/t/spec/with-unicode-multibyte.yml
@@ -2,5 +2,5 @@
 properties:
   foo:
     enum:
-    - foo–bar
+    - foo♫bar
 type: object

--- a/t/spec/with-unicode-multibyte.yml
+++ b/t/spec/with-unicode-multibyte.yml
@@ -3,4 +3,8 @@ properties:
   foo:
     enum:
     - foo♫bar
+  bar:
+    enum:
+    - replacement�char
+
 type: object

--- a/t/spec/with-unicode-multibyte.yml
+++ b/t/spec/with-unicode-multibyte.yml
@@ -1,0 +1,6 @@
+---
+properties:
+  foo:
+    enum:
+    - foo–bar
+type: object

--- a/t/unicode-multibyte.t
+++ b/t/unicode-multibyte.t
@@ -9,15 +9,23 @@ binmode($builder->output, ':encoding(UTF-8)');
 binmode($builder->failure_output, ':encoding(UTF-8)');
 binmode($builder->todo_output, ':encoding(UTF-8)');
 
-my $perl_utf8_str = "foo\x{266b}bar";
-my $encoded_bytes = encode('UTF-8', $perl_utf8_str);
 my $json_file = path(__FILE__)->dirname->child('spec')->child('with-unicode-multibyte.json');
 my $yaml_file = path(__FILE__)->dirname->child('spec')->child('with-unicode-multibyte.yml');
+
+my $perl_utf8_str = "foo\x{266b}bar";
+my $encoded_bytes = encode('UTF-8', $perl_utf8_str);
+my $with_replacement_char = "replacement\x{fffd}char";
+my $invalid_utf8_1 = "replacement\x{d800}char";
+my $invalid_utf8_2 = "replacement\x{d8f0}char";
 
 validate_ok {foo => $perl_utf8_str}, $json_file;
 validate_ok {foo => $encoded_bytes}, $json_file, E('/foo', "Not in enum list: $perl_utf8_str.");
 
 validate_ok {foo => $perl_utf8_str}, $yaml_file;
 validate_ok {foo => $encoded_bytes}, $yaml_file, E('/foo', "Not in enum list: $perl_utf8_str.");
+
+validate_ok {bar => $with_replacement_char}, $json_file;
+validate_ok {bar => $invalid_utf8_1}, $json_file, E('/bar', "Not in enum list: $with_replacement_char.");
+validate_ok {bar => $invalid_utf8_2}, $json_file, E('/bar', "Not in enum list: $with_replacement_char.");
 
 done_testing;

--- a/t/unicode-multibyte.t
+++ b/t/unicode-multibyte.t
@@ -1,0 +1,23 @@
+use lib '.';
+use t::Helper;
+use Mojo::File 'path';
+use Mojo::Util 'encode';
+use Test::More;
+
+my $builder = Test::More->builder;
+binmode($builder->output, ':encoding(UTF-8)');
+binmode($builder->failure_output, ':encoding(UTF-8)');
+binmode($builder->todo_output, ':encoding(UTF-8)');
+
+my $perl_utf8_str = "foo\x{2013}bar";
+my $encoded_bytes = encode('UTF-8', $perl_utf8_str);
+my $json_file = path(__FILE__)->dirname->child('spec')->child('with-unicode-multibyte.json');
+my $yaml_file = path(__FILE__)->dirname->child('spec')->child('with-unicode-multibyte.yml');
+
+validate_ok {foo => $perl_utf8_str}, $json_file;
+validate_ok {foo => $encoded_bytes}, $json_file, E('/foo', "Not in enum list: $perl_utf8_str.");
+
+validate_ok {foo => $perl_utf8_str}, $yaml_file;
+validate_ok {foo => $encoded_bytes}, $yaml_file, E('/foo', "Not in enum list: $perl_utf8_str.");
+
+done_testing;

--- a/t/unicode-multibyte.t
+++ b/t/unicode-multibyte.t
@@ -4,11 +4,6 @@ use Mojo::File qw(path);
 use Mojo::Util qw(encode);
 use Test::More;
 
-my $builder = Test::More->builder;
-binmode($builder->output, ':encoding(UTF-8)');
-binmode($builder->failure_output, ':encoding(UTF-8)');
-binmode($builder->todo_output, ':encoding(UTF-8)');
-
 my $json_file = path(__FILE__)->dirname->child('spec')->child('with-unicode-multibyte.json');
 my $yaml_file = path(__FILE__)->dirname->child('spec')->child('with-unicode-multibyte.yml');
 

--- a/t/unicode-multibyte.t
+++ b/t/unicode-multibyte.t
@@ -9,7 +9,7 @@ binmode($builder->output, ':encoding(UTF-8)');
 binmode($builder->failure_output, ':encoding(UTF-8)');
 binmode($builder->todo_output, ':encoding(UTF-8)');
 
-my $perl_utf8_str = "foo\x{2013}bar";
+my $perl_utf8_str = "foo\x{266b}bar";
 my $encoded_bytes = encode('UTF-8', $perl_utf8_str);
 my $json_file = path(__FILE__)->dirname->child('spec')->child('with-unicode-multibyte.json');
 my $yaml_file = path(__FILE__)->dirname->child('spec')->child('with-unicode-multibyte.yml');

--- a/t/unicode-multibyte.t
+++ b/t/unicode-multibyte.t
@@ -1,7 +1,7 @@
 use lib '.';
 use t::Helper;
-use Mojo::File 'path';
-use Mojo::Util 'encode';
+use Mojo::File qw(path);
+use Mojo::Util qw(encode);
 use Test::More;
 
 my $builder = Test::More->builder;


### PR DESCRIPTION
### Summary
Allow JSON::Validator to validate schema with unicode strings.

### Motivation

I ran into this problem with a 3rd party json schema over which I have no control.

### References
This is the same issue described in #261 although I ran into it with an enum rather than uniqueItems.

The user of JSON::Validator does not have control over bytes vs. strings as given to data_checksum. When a schema comes from JSON, strings are decoded into strings of perl characters. The YAML modules decode to perl strings as well.

I had a similar fix to the one mentioned in that issue with a couple exceptions:

I did not copy the argument unless necessary because I wasn't sure if that was intentionally avoided in the original code.

I encode unconditionally the stringified scalar which is fed into the digest. This is intentional to avoid incorrectly accepted doubly-encoded UTF-8 as valid. That is demonstrated in the included tests.

I ran t/benchmark.t with n=200, n=500, and n=1000 against the previous code and this updated code and was not able to get any differences beyond noise.